### PR TITLE
Post Date Aggregation for Yearly Intervals

### DIFF
--- a/lib/aggregations/class-post-date.php
+++ b/lib/aggregations/class-post-date.php
@@ -55,8 +55,8 @@ class Post_Date extends Aggregation {
 		switch ( $this->interval ) {
 			case 'year':
 				// Since we want all the months in a single year, set interval to months and offset by eleven months.
-				$interval       = 'M';
-				$offset         = 11;
+				$interval = 'M';
+				$offset   = 11;
 				// TODO ensure that the offset date is 01-01 00:00:00, rather than 01-01-31 23:59:59.
 				$to_unformatted = $queried_date . '-12-31 23:59:59';
 				break;

--- a/lib/aggregations/class-post-date.php
+++ b/lib/aggregations/class-post-date.php
@@ -57,7 +57,7 @@ class Post_Date extends Aggregation {
 				// Since we want all the months in a single year, set interval to months and offset by eleven months.
 				$interval = 'M';
 				$offset   = 11;
-				// TODO ensure that the offset date is 01-01 00:00:00, rather than 01-01-31 23:59:59.
+				// TODO ensure that the offset date is 01-01 00:00:00, rather than 01-31 23:59:59.
 				$to_unformatted = $queried_date . '-12-31 23:59:59';
 				break;
 			case 'quarter':

--- a/lib/aggregations/class-post-date.php
+++ b/lib/aggregations/class-post-date.php
@@ -49,9 +49,9 @@ class Post_Date extends Aggregation {
 	 *
 	 * @param string $queried_date The queried date value.
 	 *
-	 * @return array|null An array containing timestamps for from and to. Null if no query is present.
+	 * @return array An array containing timestamps for from and to. Null if no query is present.
 	 */
-	private function get_date_range( string $queried_date ) : ?array {
+	private function get_date_range( string $queried_date ) : array {
 		switch ( $this->interval ) {
 			case 'year':
 				// Since we want all the months in a single year, set interval to months and offset by eleven months.

--- a/lib/aggregations/class-post-date.php
+++ b/lib/aggregations/class-post-date.php
@@ -47,15 +47,17 @@ class Post_Date extends Aggregation {
 	 * Since a post cannot be published at multiple DateTimes, only one (the first)
 	 * queried post_date value is applied to the DSL.
 	 *
+	 * @param string $queried_date The queried date value.
+	 *
 	 * @return array|null An array containing timestamps for from and to. Null if no query is present.
 	 */
 	private function get_date_range( string $queried_date ) : ?array {
 		switch ( $this->interval ) {
 			case 'year':
 				// Since we want all the months in a single year, set interval to months and offset by eleven months.
-				$interval         = 'M';
-				$offset           = 11;
-				$to_unformatted   = $queried_date . '-12-01 00:00:00';
+				$interval       = 'M';
+				$offset         = 11;
+				$to_unformatted = $queried_date . '-12-01 00:00:00';
 				break;
 			case 'quarter':
 				// TODO Write calculation logic for defining quarterly periods.

--- a/lib/aggregations/class-post-date.php
+++ b/lib/aggregations/class-post-date.php
@@ -57,7 +57,8 @@ class Post_Date extends Aggregation {
 				// Since we want all the months in a single year, set interval to months and offset by eleven months.
 				$interval       = 'M';
 				$offset         = 11;
-				$to_unformatted = $queried_date . '-12-01 00:00:00';
+				// TODO ensure that the offset date is 01-01 00:00:00, rather than 01-01-31 23:59:59.
+				$to_unformatted = $queried_date . '-12-31 23:59:59';
 				break;
 			case 'quarter':
 				// TODO Write calculation logic for defining quarterly periods.


### PR DESCRIPTION
* Add framework for calculating post_date agg intervals.
* Update agg keys/label for human readability, see `key_as_string` comments.
* Update post_date aggs to work for yearly intervals.