### PR TITLE
Ensure key in date range is a string

### DIFF
--- a/lib/aggregations/class-relative-date.php
+++ b/lib/aggregations/class-relative-date.php
@@ -110,7 +110,7 @@ class Relative_Date extends Aggregation {
 		$intervals = [];
 		foreach ( $this->intervals as $interval ) {
 			$intervals[] = array_merge(
-				[ 'key' => $interval ],
+				[ 'key' => (string) $interval ],
 				$this->get_relative_date( $interval )
 			);
 		}


### PR DESCRIPTION
If the key is a number, it causes a parsing error on some versions of Elasticsearch.