### PR TITLE
Fix Taxonomy Aggregation Filtering for VIP Enterprise Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ add_action(
 
 For detailed information on all configuration options, action and filter hooks,
 and how to integrate aggregation controls into the search template, see
-[the wiki](/alleyinteractive/elasticsearch-extensions/wiki).
+[the wiki](https://github.com/alleyinteractive/elasticsearch-extensions/wiki).

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -103,6 +103,14 @@ class VIP_Enterprise_Search extends Adapter {
 		$use_filter = ! empty( $formatted_args['query']['bool']['filter'] );
 		foreach ( $this->get_aggregations() as $aggregation ) {
 			$filter = $aggregation->filter();
+
+			// Some filters return an indexed array (e.g. taxonomy, CAP), whereas some do not.
+			// This standardizes the shape of the filter.
+			if ( ! isset( $filter[0] ) ) {
+				$filter = [ $filter ];
+			}
+			$filter = array_filter( $filter );
+
 			if ( ! empty( $filter ) ) {
 				if ( $use_filter ) {
 					// If we aren't using a search term, just use a basic query filter.

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -89,11 +89,6 @@ class VIP_Enterprise_Search extends Adapter {
 	 * @return array The modified Elasticsearch query arguments.
 	 */
 	public function filter__ep_post_formatted_args( $formatted_args, $args ) {
-		// Enable empty search, if requested.
-		if ( $this->get_allow_empty_search() && ! empty( $args['s'] ) ) {
-			unset( $formatted_args['query']['match_all'] );
-		}
-
 		// Add requested aggregations.
 		foreach ( $this->get_aggregations() as $aggregation ) {
 			$filter = $aggregation->filter();

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -103,14 +103,6 @@ class VIP_Enterprise_Search extends Adapter {
 		$use_filter = ! empty( $formatted_args['query']['bool']['filter'] );
 		foreach ( $this->get_aggregations() as $aggregation ) {
 			$filter = $aggregation->filter();
-
-			// Some filters return an indexed array (e.g. taxonomy, CAP), whereas some do not.
-			// This standardizes the shape of the filter.
-			if ( ! isset( $filter[0] ) ) {
-				$filter = [ $filter ];
-			}
-			$filter = array_filter( $filter );
-
 			if ( ! empty( $filter ) ) {
 				if ( $use_filter ) {
 					// If we aren't using a search term, just use a basic query filter.

--- a/lib/aggregations/class-aggregation.php
+++ b/lib/aggregations/class-aggregation.php
@@ -139,10 +139,10 @@ abstract class Aggregation {
 	}
 
 	/**
-	 * Get DSL for filters that should be applied in the DSL in order to match
-	 * the requested values.
+	 * Gets an array of DSL representing each filter for this aggregation that
+	 * should be applied in the query in order to match the requested values.
 	 *
-	 * @return array|null DSL fragment or null if no filters to apply.
+	 * @return array|null Array of DSL fragments or null if no filters to apply.
 	 */
 	abstract public function filter(): ?array;
 

--- a/lib/aggregations/class-aggregation.php
+++ b/lib/aggregations/class-aggregation.php
@@ -132,7 +132,7 @@ abstract class Aggregation {
 		 * @param string $query_var    The query var being extracted.
 		 */
 		return apply_filters(
-			'elasticsearch_extensions_query_values',
+			'elasticsearch_extensions_aggregation_query_values',
 			array_values( array_filter( (array) ( $_GET['fs'][ $query_var ] ?? [] ) ) ), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
 			$query_var
 		);
@@ -259,7 +259,7 @@ abstract class Aggregation {
 		 * @param Bucket[]    $buckets     The array of buckets to filter.
 		 * @param Aggregation $aggregation The aggregation that the buckets are associated with.
 		 */
-		$this->buckets = apply_filters( 'elasticsearch_extensions_buckets', $this->sort_buckets( $buckets ), $this );
+		$this->buckets = apply_filters( 'elasticsearch_extensions_aggregation_buckets', $this->sort_buckets( $buckets ), $this );
 	}
 
 	/**

--- a/lib/aggregations/class-aggregation.php
+++ b/lib/aggregations/class-aggregation.php
@@ -142,9 +142,9 @@ abstract class Aggregation {
 	 * Gets an array of DSL representing each filter for this aggregation that
 	 * should be applied in the query in order to match the requested values.
 	 *
-	 * @return array|null Array of DSL fragments or null if no filters to apply.
+	 * @return array Array of DSL fragments to apply.
 	 */
-	abstract public function filter(): ?array;
+	abstract public function filter(): array;
 
 	/**
 	 * Gets a list of results for this aggregation.

--- a/lib/aggregations/class-aggregation.php
+++ b/lib/aggregations/class-aggregation.php
@@ -126,15 +126,15 @@ abstract class Aggregation {
 		$query_var = $key ?: $this->get_query_var();
 
 		/**
-		 * Filters extracted query values for a given query var.
+		 * Filters extracted query values for a given aggregation.
 		 *
-		 * @param array  $query_values The array of extracted query values.
-		 * @param string $query_var    The query var being extracted.
+		 * @param array       $query_values The array of extracted query values.
+		 * @param Aggregation $aggregation  The aggregation being processed.
 		 */
 		return apply_filters(
 			'elasticsearch_extensions_aggregation_query_values',
 			array_values( array_filter( (array) ( $_GET['fs'][ $query_var ] ?? [] ) ) ), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
-			$query_var
+			$this
 		);
 	}
 

--- a/lib/aggregations/class-custom-date-range.php
+++ b/lib/aggregations/class-custom-date-range.php
@@ -32,10 +32,10 @@ class Custom_Date_Range extends Aggregation {
 	}
 
 	/**
-	 * Get DSL for filters that should be applied in the DSL in order to match
-	 * the requested values.
+	 * Gets an array of DSL representing each filter for this aggregation that
+	 * should be applied in the query in order to match the requested values.
 	 *
-	 * @return array|null DSL fragment or null if no filters to apply.
+	 * @return array|null Array of DSL fragments or null if no filters to apply.
 	 */
 	public function filter(): ?array {
 		return ! empty( $this->query_values[0] )
@@ -43,10 +43,12 @@ class Custom_Date_Range extends Aggregation {
 			&& is_string( $this->query_values[0] )
 			&& is_string( $this->query_values[1] )
 			&& count( $this->query_values ) === 2
-				? $this->dsl->range(
-					'post_date',
-					$this->get_date_range( $this->query_values[0], $this->query_values[1] )
-				) : null;
+				? [
+					$this->dsl->range(
+						'post_date',
+						$this->get_date_range( $this->query_values[0], $this->query_values[1] )
+					),
+				] : null;
 	}
 
 	/**

--- a/lib/aggregations/class-custom-date-range.php
+++ b/lib/aggregations/class-custom-date-range.php
@@ -35,9 +35,9 @@ class Custom_Date_Range extends Aggregation {
 	 * Gets an array of DSL representing each filter for this aggregation that
 	 * should be applied in the query in order to match the requested values.
 	 *
-	 * @return array|null Array of DSL fragments or null if no filters to apply.
+	 * @return array Array of DSL fragments to apply.
 	 */
-	public function filter(): ?array {
+	public function filter(): array {
 		return ! empty( $this->query_values[0] )
 			&& ! empty( $this->query_values[1] )
 			&& is_string( $this->query_values[0] )
@@ -48,7 +48,7 @@ class Custom_Date_Range extends Aggregation {
 						'post_date',
 						$this->get_date_range( $this->query_values[0], $this->query_values[1] )
 					),
-				] : null;
+				] : [];
 	}
 
 	/**

--- a/lib/aggregations/class-post-date.php
+++ b/lib/aggregations/class-post-date.php
@@ -148,17 +148,19 @@ class Post_Date extends Aggregation {
 	}
 
 	/**
-	 * Get DSL for filters that should be applied in the DSL in order to match
-	 * the requested values.
+	 * Gets an array of DSL representing each filter for this aggregation that
+	 * should be applied in the query in order to match the requested values.
 	 *
-	 * @return array|null DSL fragment or null if no filters to apply.
+	 * @return array|null Array of DSL fragments or null if no filters to apply.
 	 */
 	public function filter(): ?array {
 		return ! empty( $this->query_values[0] )
-			? $this->dsl->range(
-				'post_date',
-				$this->get_date_range( (string) $this->query_values[0] )
-			) : null;
+			? [
+				$this->dsl->range(
+					'post_date',
+					$this->get_date_range( (string) $this->query_values[0] )
+				),
+			] : null;
 	}
 
 	/**

--- a/lib/aggregations/class-post-date.php
+++ b/lib/aggregations/class-post-date.php
@@ -151,16 +151,16 @@ class Post_Date extends Aggregation {
 	 * Gets an array of DSL representing each filter for this aggregation that
 	 * should be applied in the query in order to match the requested values.
 	 *
-	 * @return array|null Array of DSL fragments or null if no filters to apply.
+	 * @return array Array of DSL fragments to apply.
 	 */
-	public function filter(): ?array {
+	public function filter(): array {
 		return ! empty( $this->query_values[0] )
 			? [
 				$this->dsl->range(
 					'post_date',
 					$this->get_date_range( (string) $this->query_values[0] )
 				),
-			] : null;
+			] : [];
 	}
 
 	/**

--- a/lib/aggregations/class-post-type.php
+++ b/lib/aggregations/class-post-type.php
@@ -29,14 +29,14 @@ class Post_Type extends Aggregation {
 	}
 
 	/**
-	 * Get DSL for filters that should be applied in the DSL in order to match
-	 * the requested values.
+	 * Gets an array of DSL representing each filter for this aggregation that
+	 * should be applied in the query in order to match the requested values.
 	 *
-	 * @return array|null DSL fragment or null if no filters to apply.
+	 * @return array|null Array of DSL fragments or null if no filters to apply.
 	 */
 	public function filter(): ?array {
 		return ! empty( $this->query_values )
-			? $this->dsl->terms( 'post_type', $this->query_values )
+			? [ $this->dsl->terms( 'post_type', $this->query_values ) ]
 			: null;
 	}
 

--- a/lib/aggregations/class-post-type.php
+++ b/lib/aggregations/class-post-type.php
@@ -32,12 +32,12 @@ class Post_Type extends Aggregation {
 	 * Gets an array of DSL representing each filter for this aggregation that
 	 * should be applied in the query in order to match the requested values.
 	 *
-	 * @return array|null Array of DSL fragments or null if no filters to apply.
+	 * @return array Array of DSL fragments to apply.
 	 */
-	public function filter(): ?array {
+	public function filter(): array {
 		return ! empty( $this->query_values )
 			? [ $this->dsl->terms( 'post_type', $this->query_values ) ]
-			: null;
+			: [];
 	}
 
 	/**

--- a/lib/aggregations/class-relative-date.php
+++ b/lib/aggregations/class-relative-date.php
@@ -45,16 +45,16 @@ class Relative_Date extends Aggregation {
 	 * Gets an array of DSL representing each filter for this aggregation that
 	 * should be applied in the query in order to match the requested values.
 	 *
-	 * @return array|null Array of DSL fragments or null if no filters to apply.
+	 * @return array Array of DSL fragments to apply.
 	 */
-	public function filter(): ?array {
+	public function filter(): array {
 		return ! empty( $this->query_values[0] )
 			? [
 				$this->dsl->range(
 					'post_date',
 					$this->get_relative_date( (int) $this->query_values[0] )
 				),
-			] : null;
+			] : [];
 	}
 
 	/**

--- a/lib/aggregations/class-relative-date.php
+++ b/lib/aggregations/class-relative-date.php
@@ -42,17 +42,19 @@ class Relative_Date extends Aggregation {
 	}
 
 	/**
-	 * Get DSL for filters that should be applied in the DSL in order to match
-	 * the requested values.
+	 * Gets an array of DSL representing each filter for this aggregation that
+	 * should be applied in the query in order to match the requested values.
 	 *
-	 * @return array|null DSL fragment or null if no filters to apply.
+	 * @return array|null Array of DSL fragments or null if no filters to apply.
 	 */
 	public function filter(): ?array {
 		return ! empty( $this->query_values[0] )
-			? $this->dsl->range(
-				'post_date',
-				$this->get_relative_date( (int) $this->query_values[0] )
-			) : null;
+			? [
+				$this->dsl->range(
+					'post_date',
+					$this->get_relative_date( (int) $this->query_values[0] )
+				),
+			] : null;
 	}
 
 	/**

--- a/lib/aggregations/class-relative-date.php
+++ b/lib/aggregations/class-relative-date.php
@@ -85,7 +85,7 @@ class Relative_Date extends Aggregation {
 	public function parse_buckets( array $buckets ): void {
 		$bucket_objects = [];
 		foreach ( $buckets as $bucket ) {
-			$bucket_objects[] = new Bucket(
+			$bucket_objects[ (int) $bucket['key'] ] = new Bucket(
 				$bucket['key'],
 				$bucket['doc_count'],
 				sprintf(
@@ -96,7 +96,8 @@ class Relative_Date extends Aggregation {
 				$this->is_selected( $bucket['key'] ),
 			);
 		}
-		$this->set_buckets( $bucket_objects );
+		ksort( $bucket_objects );
+		$this->set_buckets( array_values( $bucket_objects ) );
 	}
 
 	/**

--- a/lib/aggregations/class-relative-date.php
+++ b/lib/aggregations/class-relative-date.php
@@ -85,7 +85,7 @@ class Relative_Date extends Aggregation {
 	public function parse_buckets( array $buckets ): void {
 		$bucket_objects = [];
 		foreach ( $buckets as $bucket ) {
-			$bucket_objects[ (int) $bucket['key'] ] = new Bucket(
+			$bucket_objects[] = new Bucket(
 				$bucket['key'],
 				$bucket['doc_count'],
 				sprintf(
@@ -96,8 +96,7 @@ class Relative_Date extends Aggregation {
 				$this->is_selected( $bucket['key'] ),
 			);
 		}
-		ksort( $bucket_objects );
-		$this->set_buckets( array_values( $bucket_objects ) );
+		$this->set_buckets( $bucket_objects );
 	}
 
 	/**

--- a/lib/aggregations/class-taxonomy.php
+++ b/lib/aggregations/class-taxonomy.php
@@ -18,14 +18,16 @@ use WP_Taxonomy;
 class Taxonomy extends Aggregation {
 
 	/**
-	 * The mode by which comparisons are made in filtering. If set to AND, all
-	 * specified terms must match. If set to OR, only one of the specified
-	 * terms needs to match. Defaults to AND so that selecting additional terms
-	 * makes the result set smaller, not larger.
+	 * The logical relationship between each selected term when there is more
+	 * than one. If set to AND, all specified terms must be present on a single
+	 * post in order for it to be included in the results. If set to OR, only
+	 * one of the specified terms needs to be present on a single post in order
+	 * for it to be included in the results. Defaults to AND so that selecting
+	 * additional terms makes the result set smaller, not larger.
 	 *
 	 * @var string
 	 */
-	protected string $compare = 'AND';
+	protected string $relation = 'AND';
 
 	/**
 	 * A reference to the taxonomy this aggregation is associated with.
@@ -71,7 +73,7 @@ class Taxonomy extends Aggregation {
 		// Fork for AND vs. OR logic.
 		$filters = [];
 		$field   = $this->dsl->map_tax_field( $this->taxonomy->name, $this->get_term_field() );
-		if ( 'OR' === $this->compare ) {
+		if ( 'OR' === $this->relation ) {
 			$filters[] = $this->dsl->terms( $field, $this->query_values );
 		} else {
 			foreach ( $this->query_values as $query_value ) {

--- a/lib/aggregations/class-taxonomy.php
+++ b/lib/aggregations/class-taxonomy.php
@@ -61,11 +61,11 @@ class Taxonomy extends Aggregation {
 	 * Gets an array of DSL representing each filter for this aggregation that
 	 * should be applied in the query in order to match the requested values.
 	 *
-	 * @return array|null Array of DSL fragments or null if no filters to apply.
+	 * @return array Array of DSL fragments to apply.
 	 */
-	public function filter(): ?array {
+	public function filter(): array {
 		if ( empty( $this->query_values ) ) {
-			return null;
+			return [];
 		}
 
 		// Fork for AND vs. OR logic.

--- a/lib/aggregations/class-taxonomy.php
+++ b/lib/aggregations/class-taxonomy.php
@@ -58,10 +58,10 @@ class Taxonomy extends Aggregation {
 	}
 
 	/**
-	 * Get DSL for filters that should be applied in the DSL in order to match
-	 * the requested values.
+	 * Gets an array of DSL representing each filter for this aggregation that
+	 * should be applied in the query in order to match the requested values.
 	 *
-	 * @return array|null DSL fragment or null if no filters to apply.
+	 * @return array|null Array of DSL fragments or null if no filters to apply.
 	 */
 	public function filter(): ?array {
 		if ( empty( $this->query_values ) ) {

--- a/lib/class-dsl.php
+++ b/lib/class-dsl.php
@@ -133,14 +133,11 @@ class DSL {
 	/**
 	 * Build a "filter" bool fragment for an array of terms.
 	 *
-	 * @param string $taxonomy Taxonomy slug.
-	 * @param string $field    Taxonomy field to check against.
-	 * @param array  $values   Values to match.
-	 *
+	 * @param  string $field  ES field.
+	 * @param  array  $values Values to match.
 	 * @return array DSL fragment.
 	 */
-	public function all_terms( string $taxonomy, string $field, array $values ): array {
-		$field   = $this->map_tax_field( $taxonomy, $field );
+	public static function all_terms( string $field, array $values ): array {
 		$queries = [];
 		foreach ( $values as $value ) {
 			$queries[] = [


### PR DESCRIPTION
- Standardizes the `filter` function in all aggregations to return an array of filters so that they can be merged together with other filter requirements via `array_merge`.
- Switches taxonomy filtering from OR to AND by default and introduces a configuration option to change the behavior to OR if desired.
- Handles adding filters to VIP Enterprise Search properly depending on whether a search term was specified or not. If a term was not specified, copies over the `post_filter` directive as a query filter (which otherwise would not be applied) and then augments it with the aggregation selections. If a search term was specified, integrates the filters properly into the `function_score` query produced by ElasticPress.
- Removes unneeded code in the `ep_post_formatted_args` filter callback related to allowing empty search.
- Changes `all_terms` in the DSL class to require a mapped field so that it can be used for more than just taxonomy terms.
- Renames the `elasticsearch_extensions_buckets` filter to `elasticsearch_extensions_aggregation_buckets` to associate it with aggregations.
- Renames the `elasticsearch_extensions_query_values` filter to `elasticsearch_extensions_aggregation_query_values` to associate it with aggregations, and changes the second parameter from the query var to the `Aggregation` object for greater flexibility.