### PR TITLE
Add input templating function and specific template for custom date range

### DIFF
--- a/lib/aggregations/class-aggregation.php
+++ b/lib/aggregations/class-aggregation.php
@@ -183,6 +183,16 @@ abstract class Aggregation {
 	}
 
 	/**
+	 * Outputs the default form inputs for this aggregation. Defaults to
+	 * checkboxes, but can be overridden in individual aggregation classes if a
+	 * different input format makes more logical sense, or to create a totally
+	 * custom input fieldset.
+	 */
+	public function input(): void {
+		$this->checkboxes();
+	}
+
+	/**
 	 * Determines whether the specified key is selected in the query for this
 	 * aggregation.
 	 *

--- a/lib/aggregations/class-relative-date.php
+++ b/lib/aggregations/class-relative-date.php
@@ -77,6 +77,14 @@ class Relative_Date extends Aggregation {
 	}
 
 	/**
+	 * Overrides the default input function for aggregations to use a select
+	 * input for this aggregation.
+	 */
+	public function input(): void {
+		$this->select();
+	}
+
+	/**
 	 * Given a raw array of Elasticsearch aggregation buckets, parses it into
 	 * Bucket objects and saves them in this object.
 	 *


### PR DESCRIPTION
- Adds a generic templating function called `input` that can be used on any aggregation to output a recommended set of form controls for the aggregation, which can be overridden by individual aggregations to customize the form fields.
- Sets the default for all aggregations to checkboxes.
- Defaults the relative date aggregation to a select.
- Adds a custom set of inputs for the custom date range aggregation's `input` function which handles date selection using a built-in date input and a hidden field to track the ISO-8601 date separately from the date input.