### PR TITLE
Only load dev dependencies in a dev context

### DIFF
--- a/elasticsearch-extensions.php
+++ b/elasticsearch-extensions.php
@@ -15,9 +15,6 @@
 use Elasticsearch_Extensions\Controller;
 use Elasticsearch_Extensions\Registry;
 
-// Load Composer dependencies.
-require_once __DIR__ . '/vendor/wordpress-autoload.php';
-
 require_once __DIR__ . '/lib/autoload.php';
 
 /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,20 +6,21 @@
  * @subpackage Tests
  */
 
-define( 'ELASTICSEARCH_EXTENSIONS_TESTS_DIR', dirname( __DIR__ ) . '/tests/' );
+// Load Composer's autoloader.
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 
 Mantle\Testing\manager()
 	->before( function() {
 		// Define bootstrap helper functions.
-		require_once ELASTICSEARCH_EXTENSIONS_TESTS_DIR . '/includes/bootstrap-functions.php';
+		require_once __DIR__ . '/includes/bootstrap-functions.php';
 
 		// Load adapters bootstrap files.
-		require_once ELASTICSEARCH_EXTENSIONS_TESTS_DIR . '/includes/searchpress-bootstrap.php';
+		require_once __DIR__ . '/includes/searchpress-bootstrap.php';
 
 		// Loading Elasticsearch Extensions testcases.
-		require_once ELASTICSEARCH_EXTENSIONS_TESTS_DIR . '/includes/class-adapter-unit-test-case.php';
-		require_once ELASTICSEARCH_EXTENSIONS_TESTS_DIR . '/includes/class-searchpress-unit-test-case.php';
-		require_once ELASTICSEARCH_EXTENSIONS_TESTS_DIR . '/includes/class-vip-enterprise-search-unit-test-case.php';
+		require_once __DIR__ . '/includes/class-adapter-unit-test-case.php';
+		require_once __DIR__ . '/includes/class-searchpress-unit-test-case.php';
+		require_once __DIR__ . '/includes/class-vip-enterprise-search-unit-test-case.php';
 
 		uses( \SearchPress_Adapter_UnitTestCase::class)->in('adapters/searchpress' );
 		uses( \VIP_Enterprise_Search_Adapter_UnitTestCase::class)->in('adapters/vip-search' );


### PR DESCRIPTION
The WordPress autoloader is a dependency of the Pest plugin, which will only be needed when running unit tests, and won't be installed by `composer install --no-dev` as should be used in production. Additionally, the WordPress autoloader is loaded automatically when loading the Composer autoloader, so we're just loading the Composer autoloader in the bootstrap file for tests rather than as part of normal plugin operation.