### PR TITLE
Add support for search-as-you-type suggestions

### DIFF
--- a/lib/adapters/class-adapter.php
+++ b/lib/adapters/class-adapter.php
@@ -301,8 +301,10 @@ abstract class Adapter implements Hookable {
 	/**
 	 * Suggest posts that match the given search term.
 	 *
-	 * @param string  $search   Search string
-	 * @param array   $args     {
+	 * @param string $search Search string.
+	 * @param array  $args   {
+	 *     Optional. An array of arguments.
+	 *
 	 *     @type string[] $subtypes Limit suggestions to this subset of all post
 	 *                              types that support search suggestions.
 	 *     @type int      $page     Page of results.

--- a/lib/adapters/class-adapter.php
+++ b/lib/adapters/class-adapter.php
@@ -276,7 +276,7 @@ abstract class Adapter implements Hookable {
 	}
 
 	/**
-	 * Returns whether a REST API search handler for suggestions can be enabled.
+	 * Returns whether support for a REST API search handler for suggestions is enabled.
 	 *
 	 * @return bool
 	 */

--- a/lib/adapters/class-adapter.php
+++ b/lib/adapters/class-adapter.php
@@ -208,7 +208,7 @@ abstract class Adapter implements Hookable {
 	/**
 	 * Gets the value for enable_search_suggestions.
 	 *
-	 * @return bool Whether to allow empty search or not.
+	 * @return bool Whether search suggestions are enabled.
 	 */
 	public function get_enable_search_suggestions(): bool {
 		return $this->enable_search_suggestions;

--- a/lib/adapters/class-generic.php
+++ b/lib/adapters/class-generic.php
@@ -13,7 +13,6 @@ namespace Elasticsearch_Extensions\Adapters;
  * @package Elasticsearch_Extensions
  */
 class Generic extends Adapter {
-
 	/**
 	 * Gets the field map for this adapter.
 	 *

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -90,7 +90,8 @@ class VIP_Enterprise_Search extends Adapter {
 	public function filter__ep_post_mapping( $mapping ) {
 		if ( $this->get_enable_search_suggestions() ) {
 			$mapping['mappings']['properties']['search_suggest'] = [
-				'type' => 'search_as_you_type',
+				'type'     => 'search_as_you_type',
+
 				/*
 				 * The 'ewp_word_delimiter' analyzer included by default in ElasticPress is not compatible with
 				 * this field type. See https://github.com/10up/ElasticPress/pull/3237.
@@ -259,22 +260,24 @@ class VIP_Enterprise_Search extends Adapter {
 	 * search-suggestions REST API handler in the list of allowed handlers if
 	 * search suggestions are made available over REST.
 	 *
-	 * @param $handlers
-	 * @return mixed
+	 * @param \WP_REST_Search_Handler[] $search_handlers List of search handlers to use in the controller.
+	 * @return \WP_REST_Search_Handler[] Updated list of handlers.
 	 */
-	public function filter__wp_rest_search_handlers( $handlers ) {
+	public function filter__wp_rest_search_handlers( $search_handlers ) {
 		if ( $this->is_show_search_suggestions_in_rest_enabled() ) {
-			$handlers[] = new Post_Suggestion_Search_Handler( $this );
+			$search_handlers[] = new Post_Suggestion_Search_Handler( $this );
 		}
 
-		return $handlers;
+		return $search_handlers;
 	}
 
 	/**
 	 * Suggest posts that match the given search term.
 	 *
-	 * @param string  $search   Search string
-	 * @param array   $args     {
+	 * @param string $search Search string.
+	 * @param array  $args   {
+	 *     Optional. An array of arguments.
+	 *
 	 *     @type string[] $subtypes Limit suggestions to this subset of all post
 	 *                              types that support search suggestions.
 	 *     @type int      $page     Page of results.
@@ -321,6 +324,7 @@ class VIP_Enterprise_Search extends Adapter {
 							'search_suggest._2gram',
 							'search_suggest._3gram',
 						],
+
 						/*
 						 * The purpose of using 'and' here is to assume that more terms in the search indicate
 						 * someone searching for something more specific, not someone trying to get more results.
@@ -337,7 +341,7 @@ class VIP_Enterprise_Search extends Adapter {
 					'terms' => [
 						'post_type.raw' => $subtypes,
 						'_name'         => 'subtypes',
-					]
+					],
 				];
 			}
 

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -7,6 +7,7 @@
 
 namespace Elasticsearch_Extensions\Adapters;
 
+use Elasticsearch_Extensions\REST_API\Post_Suggestion_Search_Handler;
 use WP_Query;
 
 /**
@@ -77,6 +78,57 @@ class VIP_Enterprise_Search extends Adapter {
 		}
 
 		return $filtered_post_types;
+	}
+
+	/**
+	 * A callback for the ep_post_mapping filter. Adds the 'search_suggest'
+	 * field to the mapping if search suggestions are enabled.
+	 *
+	 * @param array $mapping Post mapping.
+	 * @return array Updated mapping.
+	 */
+	public function filter__ep_post_mapping( $mapping ) {
+		if ( $this->get_enable_search_suggestions() ) {
+			$mapping['mappings']['properties']['search_suggest'] = [
+				'type' => 'search_as_you_type',
+			];
+		}
+
+		return $mapping;
+	}
+
+	/**
+	 * A callback for the ep_post_sync_args_post_prepare_meta filter. Indexes
+	 * text for the 'search_suggest' field.
+	 *
+	 * @param array $post_args Post data to be indexed.
+	 * @param int   $post_id   Post ID.
+	 * @return array Updated data to index.
+	 */
+	public function filter__ep_post_sync_args_post_prepare_meta( $post_args, $post_id ) {
+		if ( $this->get_enable_search_suggestions() ) {
+			$post = get_post( $post_id );
+
+			if ( $post ) {
+				$restrict = $this->get_restricted_search_suggestions_post_types();
+
+				if ( ! $restrict || in_array( $post->post_type, $restrict, true ) ) {
+					/**
+					 * Filters the text to be indexed in the search suggestions field for a post.
+					 *
+					 * @param string $text    Text to index. Default post title.
+					 * @param int    $post_id Post ID.
+					 */
+					$post_args['search_suggest'] = apply_filters(
+						'elasticsearch_extensions_post_search_suggestions_text',
+						$post->post_title,
+						$post_id,
+					);
+				}
+			}
+		}
+
+		return $post_args;
 	}
 
 	/**
@@ -198,6 +250,138 @@ class VIP_Enterprise_Search extends Adapter {
 	}
 
 	/**
+	 * A callback for the wp_rest_search_handlers filter. Includes the
+	 * search-suggestions REST API handler in the list of allowed handlers if
+	 * search suggestions are made available over REST.
+	 *
+	 * @param $handlers
+	 * @return mixed
+	 */
+	public function filter__wp_rest_search_handlers( $handlers ) {
+		if ( $this->is_show_search_suggestions_in_rest_enabled() ) {
+			$handlers[] = new Post_Suggestion_Search_Handler( $this );
+		}
+
+		return $handlers;
+	}
+
+	/**
+	 * Suggest posts that match the given search term.
+	 *
+	 * @param string  $search   Search string
+	 * @param array   $args     {
+	 *     @type string[] $subtypes Limit suggestions to this subset of all post
+	 *                              types that support search suggestions.
+	 *     @type int      $page     Page of results.
+	 *     @type int      $per_page Results per page. Default 10.
+	 *     @type int[]    $include  Search within these post IDs.
+	 *     @type int[]    $exclude  Exclude these post IDs from results.
+	 * }
+	 * @return int[] Post IDs in this page of results and total number of results.
+	 */
+	public function query_post_suggestions( string $search, array $args = [] ): array {
+		$out = [ [], 0 ];
+
+		$args = wp_parse_args(
+			$args,
+			[
+				'subtypes' => [],
+				'page'     => 1,
+				'per_page' => 10,
+				'exclude'  => [],
+				'include'  => [],
+			],
+		);
+
+		$subtypes = (array) $args['subtypes'];
+		$page     = (int) $args['page'];
+		$per_page = (int) $args['per_page'];
+		$exclude  = (array) $args['exclude'];
+		$include  = (array) $args['include'];
+
+		if ( $search ) {
+			$query_from     = ( $page - 1 ) * $per_page;
+			$query_per_page = $per_page;
+			$query_must     = [
+				[
+					'multi_match' => [
+						'query'    => $search,
+						'type'     => 'bool_prefix',
+						'fields'   => [
+							'search_suggest',
+							'search_suggest._2gram',
+							'search_suggest._3gram',
+						],
+						/*
+						 * The purpose of using 'and' here is to assume that more terms in the search indicate
+						 * someone searching for something more specific, not someone trying to get more results.
+						 */
+						'operator' => 'and',
+						'_name'    => 'search',
+					],
+				],
+			];
+			$query_must_not = [];
+
+			if ( $subtypes ) {
+				$query_must[] = [
+					'terms' => [
+						'post_type.raw' => $subtypes,
+						'_name'         => 'subtypes',
+					]
+				];
+			}
+
+			if ( $include ) {
+				$query_must[] = [
+					'terms' => [
+						'post_id' => $include,
+						'_name'   => 'include',
+					],
+				];
+			}
+
+			if ( $exclude ) {
+				$query_must_not[] = [
+					'terms' => [
+						'post_id' => $exclude,
+						'_name'   => 'exclude',
+					],
+				];
+			}
+
+			$query = [
+				'from'    => $query_from,
+				'size'    => $query_per_page,
+				'query'   => [
+					'bool' => [
+						'must'     => $query_must,
+						'must_not' => $query_must_not,
+					],
+				],
+				'_source' => [
+					'ID',
+				],
+			];
+
+			$result = \ElasticPress\Indexables::factory()->get( 'post' )->query_es( $query, [] );
+
+			if (
+				isset( $result['documents'] )
+				&& is_array( $result['documents'] )
+				&& isset( $result['found_documents']['value'] )
+			) {
+				$out = [
+					array_column( $result['documents'], 'ID' ),
+					$result['found_documents']['value'],
+				];
+			}
+		}
+
+		return $out;
+	}
+
+	/**
 	 * Gets the field map for this adapter.
 	 *
 	 * @return array The field map.
@@ -296,10 +480,13 @@ class VIP_Enterprise_Search extends Adapter {
 		// Register filter hooks.
 		add_filter( 'ep_elasticpress_enabled', [ $this, 'filter__ep_elasticpress_enabled' ], 10, 2 );
 		add_filter( 'ep_indexable_post_types', [ $this, 'filter__ep_indexable_post_types' ] );
+		add_filter( 'ep_post_mapping', [ $this, 'filter__ep_post_mapping' ] );
+		add_filter( 'ep_post_sync_args_post_prepare_meta', [ $this, 'filter__ep_post_sync_args_post_prepare_meta' ], 10, 2 );
 		add_filter( 'ep_post_formatted_args', [ $this, 'filter__ep_post_formatted_args' ], 10, 3 );
 		add_filter( 'ep_query_request_args', [ $this, 'filter__ep_query_request_args' ], 10, 4 );
 		add_filter( 'ep_searchable_post_types', [ $this, 'filter__ep_searchable_post_types' ] );
 		add_filter( 'vip_search_post_taxonomies_allow_list', [ $this, 'filter__vip_search_post_taxonomies_allow_list' ] );
+		add_filter( 'wp_rest_search_handlers', [ $this, 'filter__wp_rest_search_handlers' ] );
 	}
 
 	/**
@@ -313,9 +500,12 @@ class VIP_Enterprise_Search extends Adapter {
 		// Unregister filter hooks.
 		remove_filter( 'ep_elasticpress_enabled', [ $this, 'filter__ep_elasticpress_enabled' ] );
 		remove_filter( 'ep_indexable_post_types', [ $this, 'filter__ep_indexable_post_types' ] );
+		remove_filter( 'ep_post_mapping', [ $this, 'filter__ep_post_mapping' ] );
+		remove_filter( 'ep_post_sync_args_post_prepare_meta', [ $this, 'filter__ep_post_sync_args_post_prepare_meta' ] );
 		remove_filter( 'ep_post_formatted_args', [ $this, 'filter__ep_post_formatted_args' ] );
 		remove_filter( 'ep_query_request_args', [ $this, 'filter__ep_query_request_args' ] );
 		remove_filter( 'ep_searchable_post_types', [ $this, 'filter__ep_searchable_post_types' ] );
 		remove_filter( 'vip_search_post_taxonomies_allow_list', [ $this, 'filter__vip_search_post_taxonomies_allow_list' ] );
+		remove_filter( 'wp_rest_search_handlers', [ $this, 'filter__wp_rest_search_handlers' ] );
 	}
 }

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -287,6 +287,10 @@ class VIP_Enterprise_Search extends Adapter {
 	public function query_post_suggestions( string $search, array $args = [] ): array {
 		$out = [ [], 0 ];
 
+		if ( ! $search && ! $this->get_allow_empty_search() ) {
+			return $out;
+		}
+
 		$args = wp_parse_args(
 			$args,
 			[

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -338,7 +338,7 @@ class VIP_Enterprise_Search extends Adapter {
 				[
 					'terms' => [
 						'post_status' => (array) $args['status'],
-						'_name' => 'status',
+						'_name'       => 'status',
 					],
 				],
 			];

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -345,12 +345,29 @@ class VIP_Enterprise_Search extends Adapter {
 			$query_must_not = [];
 
 			if ( $subtypes ) {
-				$query_must[] = [
-					'terms' => [
-						'post_type.raw' => $subtypes,
-						'_name'         => 'subtypes',
-					],
-				];
+				$restrict = $this->get_restricted_search_suggestions_post_types();
+
+				/*
+				 * If search suggestions have been limited to a list of post types,
+				 * don't suggest posts from any other types, even if posts in other
+				 * types have suggestions indexed because they used to be allowed.
+				 */
+				if ( $restrict ) {
+					$subtypes = array_intersect( $subtypes, $restrict );
+
+					if ( ! $subtypes ) {
+						$subtypes = $restrict;
+					}
+				}
+
+				if ( $subtypes ) {
+					$query_must[] = [
+						'terms' => [
+							'post_type.raw' => $subtypes,
+							'_name'         => 'subtypes',
+						],
+					];
+				}
 			}
 
 			if ( $include ) {

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -360,14 +360,12 @@ class VIP_Enterprise_Search extends Adapter {
 					}
 				}
 
-				if ( $subtypes ) {
-					$query_must[] = [
-						'terms' => [
-							'post_type.raw' => $subtypes,
-							'_name'         => 'subtypes',
-						],
-					];
-				}
+				$query_must[] = [
+					'terms' => [
+						'post_type.raw' => $subtypes,
+						'_name'         => 'subtypes',
+					],
+				];
 			}
 
 			if ( $include ) {

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -321,6 +321,9 @@ class VIP_Enterprise_Search extends Adapter {
 		$exclude  = (array) $args['exclude'];
 		$include  = (array) $args['include'];
 
+		// Avoid returning stale data in the index.
+		$subtypes = array_filter( $subtypes, 'post_type_exists' );
+
 		if ( $search ) {
 			$query_from     = ( $page - 1 ) * $per_page;
 			$query_per_page = $per_page;

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -276,7 +276,7 @@ class VIP_Enterprise_Search extends Adapter {
 	 *
 	 * @param string $search Search string.
 	 * @param array  $args   {
-	 *     Optional. An array of arguments.
+	 *     Optional. An array of query arguments.
 	 *
 	 *     @type string[] $subtypes Limit suggestions to this subset of all post
 	 *                              types that support search suggestions.
@@ -306,6 +306,14 @@ class VIP_Enterprise_Search extends Adapter {
 				'status'   => [ 'publish' ],
 			],
 		);
+
+		/**
+		 * Filters the arguments used to build an Elasticsearch search for suggested posts.
+		 *
+		 * @param array  $args   An array of query arguments.
+		 * @param string $search Search string.
+		 */
+		$args = apply_filters( 'elasticsearch_extensions_query_post_suggestions_args', $args, $search );
 
 		$subtypes = (array) $args['subtypes'];
 		$page     = (int) $args['page'];

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -284,6 +284,7 @@ class VIP_Enterprise_Search extends Adapter {
 	 *     @type int      $per_page Results per page. Default 10.
 	 *     @type int[]    $include  Search within these post IDs.
 	 *     @type int[]    $exclude  Exclude these post IDs from results.
+	 *     @type string[] $status   Post statuses to search. Default 'publish'.
 	 * }
 	 * @return int[] Post IDs in this page of results and total number of results.
 	 */
@@ -302,6 +303,7 @@ class VIP_Enterprise_Search extends Adapter {
 				'per_page' => 10,
 				'exclude'  => [],
 				'include'  => [],
+				'status'   => [ 'publish' ],
 			],
 		);
 
@@ -331,6 +333,12 @@ class VIP_Enterprise_Search extends Adapter {
 						 */
 						'operator' => 'and',
 						'_name'    => 'search',
+					],
+				],
+				[
+					'terms' => [
+						'post_status' => (array) $args['status'],
+						'_name' => 'status',
 					],
 				],
 			];

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -54,6 +54,30 @@ class VIP_Enterprise_Search extends Adapter {
 	}
 
 	/**
+	 * A callback for the ep_default_analyzer_filters filter hook. Filters the
+	 * default Elasticsearch analyzer's filters to remove the
+	 * 'ewp_word_delimiter' filter when search suggestions are enabled, as this
+	 * filter is not always compatible with the search-as-you-type field.
+	 *
+	 * @see https://github.com/10up/ElasticPress/pull/3237.
+	 *
+	 * @param string[] $filters Default list of filters.
+	 * @return string[] The modified list of filters.
+	 */
+	public function filter__ep_default_analyzer_filters( $filters ) {
+		if ( $this->get_enable_search_suggestions() ) {
+			$ewp_word_delimiter = array_search( 'ewp_word_delimiter', $filters, true );
+
+			if ( false !== $ewp_word_delimiter ) {
+				unset( $filters[ $ewp_word_delimiter ] );
+				$filters = array_values( $filters );
+			}
+		}
+
+		return $filters;
+	}
+
+	/**
 	 * A callback for the ep_indexable_post_types filter hook. Filters the list
 	 * of post types that should be indexed in ElasticPress based on what was
 	 * configured. If no restrictions were specified, uses the default list
@@ -479,6 +503,7 @@ class VIP_Enterprise_Search extends Adapter {
 
 		// Register filter hooks.
 		add_filter( 'ep_elasticpress_enabled', [ $this, 'filter__ep_elasticpress_enabled' ], 10, 2 );
+		add_filter( 'ep_default_analyzer_filters', [ $this, 'filter__ep_default_analyzer_filters' ] );
 		add_filter( 'ep_indexable_post_types', [ $this, 'filter__ep_indexable_post_types' ] );
 		add_filter( 'ep_post_mapping', [ $this, 'filter__ep_post_mapping' ] );
 		add_filter( 'ep_post_sync_args_post_prepare_meta', [ $this, 'filter__ep_post_sync_args_post_prepare_meta' ], 10, 2 );
@@ -499,6 +524,7 @@ class VIP_Enterprise_Search extends Adapter {
 
 		// Unregister filter hooks.
 		remove_filter( 'ep_elasticpress_enabled', [ $this, 'filter__ep_elasticpress_enabled' ] );
+		remove_filter( 'ep_default_analyzer_filters', [ $this, 'filter__ep_default_analyzer_filters' ] );
 		remove_filter( 'ep_indexable_post_types', [ $this, 'filter__ep_indexable_post_types' ] );
 		remove_filter( 'ep_post_mapping', [ $this, 'filter__ep_post_mapping' ] );
 		remove_filter( 'ep_post_sync_args_post_prepare_meta', [ $this, 'filter__ep_post_sync_args_post_prepare_meta' ] );

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -301,7 +301,7 @@ class VIP_Enterprise_Search extends Adapter {
 				'subtypes' => [],
 				'page'     => 1,
 				'per_page' => 10,
-				'exclude'  => [],
+				'exclude'  => [], // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 				'include'  => [],
 				'status'   => [ 'publish' ],
 			],

--- a/lib/class-controller.php
+++ b/lib/class-controller.php
@@ -134,6 +134,8 @@ class Controller implements Hookable {
 	 * Enables search-as-you-type suggestions.
 	 *
 	 * @param array $args {
+	 *     Optional. An array of arguments.
+	 *
 	 *     @type string[] $post_types   Limit suggestions to this subset of all
 	 *                                  indexed post types.
 	 *     @type bool     $show_in_rest Whether to register REST API search handlers

--- a/lib/class-controller.php
+++ b/lib/class-controller.php
@@ -131,6 +131,35 @@ class Controller implements Hookable {
 	}
 
 	/**
+	 * Enables search-as-you-type suggestions.
+	 *
+	 * @param array $args {
+	 *     @type string[] $post_types   Limit suggestions to this subset of all
+	 *                                  indexed post types.
+	 *     @type bool     $show_in_rest Whether to register REST API search handlers
+	 *                                  for querying suggestions. Default true.
+	 * }
+	 * @return Controller The instance of the class to allow for chaining.
+	 */
+	public function enable_search_suggestions( array $args = [] ): Controller {
+		$args = wp_parse_args(
+			$args,
+			[
+				'post_types'   => [],
+				'show_in_rest' => true,
+			]
+		);
+
+		$args['post_types'] = array_filter( (array) $args['post_types'] );
+
+		$this->adapter->set_enable_search_suggestions( true );
+		$this->adapter->set_show_search_suggestions_in_rest( (bool) $args['show_in_rest'] );
+		$this->adapter->restrict_search_suggestions_post_types( $args['post_types'] );
+
+		return $this;
+	}
+
+	/**
 	 * A function to enable an aggregation for a specific taxonomy.
 	 *
 	 * @param string $taxonomy The taxonomy slug for which to enable an aggregation.

--- a/lib/rest-api/class-post-suggestion-search-handler.php
+++ b/lib/rest-api/class-post-suggestion-search-handler.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Elasticsearch Extensions Adapters: Post Suggestion REST API Search Handler
+ *
+ * @package Elasticsearch_Extensions
+ */
+
+namespace Elasticsearch_Extensions\REST_API;
+
+use Elasticsearch_Extensions\Adapters\Adapter;
+use WP_REST_Request;
+use WP_REST_Search_Controller;
+use WP_REST_Search_Handler;
+
+/**
+ * Suggest posts over the REST API.
+ */
+class Post_Suggestion_Search_Handler extends WP_REST_Search_Handler {
+	/**
+	 * Search adapter.
+	 *
+	 * @var Adapter
+	 */
+	private Adapter $adapter;
+
+	/**
+	 * Set up.
+	 *
+	 * @param Adapter $adapter Search adapter.
+	 */
+	public function __construct( Adapter $adapter ) {
+		$this->adapter = $adapter;
+		$this->type    = 'post-suggestion';
+	}
+
+	/**
+	 * Searches the object type content for a given search request.
+	 *
+	 * @param WP_REST_Request $request Full REST request.
+	 * @return array Associative array containing an `WP_REST_Search_Handler::RESULT_IDS` containing
+	 *               an array of found IDs and `WP_REST_Search_Handler::RESULT_TOTAL` containing the
+	 *               total count for the matching search results.
+	 */
+	public function search_items( WP_REST_Request $request ) {
+		$args = [
+			'subtypes' => $request[ WP_REST_Search_Controller::PROP_SUBTYPE ],
+			'page'     => $request['page'],
+			'per_page' => $request['per_page'],
+			'include'  => $request['include'],
+			'exclude'  => $request['exclude'],
+		];
+
+		if ( in_array( WP_REST_Search_Controller::TYPE_ANY, $args['subtypes'], true ) ) {
+			unset( $args['subtypes'] );
+		}
+
+		[ $ids, $total ] = $this->adapter->query_post_suggestions( $request['search'], $args );
+
+		return [
+			self::RESULT_IDS   => $ids,
+			self::RESULT_TOTAL => $total,
+		];
+	}
+
+	/**
+	 * Prepares the search result for a given ID.
+	 *
+	 * @param int|string $id     Item ID.
+	 * @param array      $fields Fields to include for the item.
+	 * @return array Associative array containing all fields for the item.
+	 */
+	public function prepare_item( $id, array $fields ) {
+		$item = [];
+		$post = get_post( $id );
+
+		if ( $post ) {
+			if ( rest_is_field_included( WP_REST_Search_Controller::PROP_ID, $fields ) ) {
+				$item[ WP_REST_Search_Controller::PROP_ID ] = $id;
+			}
+
+			if ( rest_is_field_included( WP_REST_Search_Controller::PROP_TITLE, $fields ) ) {
+				$item[ WP_REST_Search_Controller::PROP_TITLE ] = $post->post_title;
+			}
+
+			if ( rest_is_field_included( WP_REST_Search_Controller::PROP_URL, $fields ) ) {
+				$item[ WP_REST_Search_Controller::PROP_URL ] = get_permalink( $post );
+			}
+
+			if ( rest_is_field_included( WP_REST_Search_Controller::PROP_TYPE, $fields ) ) {
+				$item[ WP_REST_Search_Controller::PROP_TYPE ] = $this->get_type();
+			}
+
+			if ( rest_is_field_included( WP_REST_Search_Controller::PROP_SUBTYPE, $fields ) ) {
+				$item[ WP_REST_Search_Controller::PROP_SUBTYPE ] = $post->post_type;
+			}
+		}
+
+		return $item;
+	}
+
+	/**
+	 * Prepares links for the search result of a given ID.
+	 *
+	 * @param int|string $id Item ID.
+	 * @return array Links for the given item.
+	 */
+	public function prepare_item_links( $id ) {
+		$links = [];
+
+		$item_route = rest_get_route_for_post( $id );
+
+		if ( $item_route ) {
+			$links['self'] = [
+				'href'       => rest_url( $item_route ),
+				'embeddable' => true,
+			];
+		}
+
+		return $links;
+	}
+}

--- a/lib/rest-api/class-post-suggestion-search-handler.php
+++ b/lib/rest-api/class-post-suggestion-search-handler.php
@@ -54,7 +54,7 @@ class Post_Suggestion_Search_Handler extends WP_REST_Search_Handler {
 			unset( $args['subtypes'] );
 		}
 
-		[ $ids, $total ] = $this->adapter->query_post_suggestions( $request['search'], $args );
+		[ $ids, $total ] = $this->adapter->query_post_suggestions( (string) $request['search'], $args );
 
 		return [
 			self::RESULT_IDS   => $ids,

--- a/lib/rest-api/class-post-suggestion-search-handler.php
+++ b/lib/rest-api/class-post-suggestion-search-handler.php
@@ -47,7 +47,7 @@ class Post_Suggestion_Search_Handler extends WP_REST_Search_Handler {
 			'page'     => $request['page'],
 			'per_page' => $request['per_page'],
 			'include'  => $request['include'],
-			'exclude'  => $request['exclude'],
+			'exclude'  => $request['exclude'], // phpcs:ignore WordPressVIPMinimum.Performance.WPQueryParams.PostNotIn_exclude
 		];
 
 		if ( in_array( WP_REST_Search_Controller::TYPE_ANY, $args['subtypes'], true ) ) {

--- a/lib/rest-api/class-post-suggestion-search-handler.php
+++ b/lib/rest-api/class-post-suggestion-search-handler.php
@@ -31,6 +31,18 @@ class Post_Suggestion_Search_Handler extends WP_REST_Search_Handler {
 	public function __construct( Adapter $adapter ) {
 		$this->adapter = $adapter;
 		$this->type    = 'post-suggestion';
+
+		/*
+		 * Since adapters don't yet have a consistent way to supply the list of indexed post types,
+		 * allow any public type to be requested, even though the response might not include it.
+		 */
+		$this->subtypes = array_values(
+			get_post_types(
+				[
+					'public' => true,
+				],
+			),
+		);
 	}
 
 	/**

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,3 +3,6 @@ parameters:
 	paths:
 		- elasticsearch-extensions.php
 		- lib/
+	scanDirectories:
+		- ../elasticpress/
+		- ../searchpress/


### PR DESCRIPTION
Adds a `search_as_you_type` field to the post mapping. By default, the field is populated with the post title on posts in all indexed post types. Also by default, a REST API search handler will be registered that suggests posts for the given search term.

**Usage**

`enable_search_suggestions( array $args = [] )`

**Available Arguments**

| Key | Default | Possible Values | Description |
|-----|---------|-----------------|-------------|
| `post_types` | `[]` | (any post type name) | Limit suggestions to this subset of indexed post types. |
| `show_in_rest` | `true` | `true`, `false` | Whether to register REST API search handlers for querying suggestions. |

**Example**

```php
add_action(
	'elasticsearch_extensions_config',
	 function ( $es_config ) {
		$es_config->enable_search_suggestions(
			[
				'post_types' => [ 'post' ],
			],
		);
	 }
);
```

```bash
curl -G -d 'type=post-suggestion' -d 'search=hello' https://www.example.com/wp-json/wp/v2/search
curl -G -d 'type=post-suggestion' -d 'search=hello' -d 'subtype[]=page' https://www.example.com/wp-json/wp/v2/search
curl -G -d 'type=post-suggestion' -d 'search=hello' -d 'include=1,2,3' https://www.example.com/wp-json/wp/v2/search
curl -G -d 'type=post-suggestion' -d 'search=hello' -d 'exclude=1,2,3' https://www.example.com/wp-json/wp/v2/search
```

## Filters

elasticsearch_extensions_post_search_suggestions_text

Filters the text to be indexed in the search suggestions field for a post.

**Usage**

`apply_filters( 'elasticsearch_extensions_post_search_suggestions_text', string $text, int $post_id );`

**Parameters**

`$text`

*string* Text to index. Default post title.

`$post_id`

*int* Post ID.

**Example**

```php
add_filter(
	'elasticsearch_extensions_post_search_suggestions_text',
	function ( $text, $post_id ) {
		$seo_title = get_post_meta( $post_id, '_seo_title', true );

		if ( $seo_title ) {
			$text = $seo_title;
		}

		return $text;
	},
	10,
	2
);
```

## Still to do

* [x] Fix REST subtypes
* [x] Centralize search text function
* [x] CS