### PR TITLE
Fix `unhook()` priority mismatch

### DIFF
--- a/lib/class-controller.php
+++ b/lib/class-controller.php
@@ -228,6 +228,6 @@ class Controller implements Hookable {
 	 * Unregisters action and/or filter hooks with WordPress.
 	 */
 	public function unhook(): void {
-		remove_action( 'init', [ $this, 'action__init' ], 99 );
+		remove_action( 'init', [ $this, 'action__init' ], 1000 );
 	}
 }


### PR DESCRIPTION
`Controller::action__init()` is hooked to `init:1000`, not `99`. Ref:

https://github.com/alleyinteractive/elasticsearch-extensions/blob/62014c7e02229d7dc43bb4d2111a02d0b7e21fc5/lib/class-controller.php#L182.