### PR TITLE
add agg support for match_all queries 

### DIFF
--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -167,7 +167,9 @@ class VIP_Enterprise_Search extends Adapter {
 			} elseif ( ! empty( $formatted_args['query']['match_all'] ) ) {
 				// Add filters to a match_all queries. This happens on secondary queries that use ep_integrate.
 				$formatted_args['query']['bool']['must']['match_all'] = $formatted_args['query']['match_all'];
+				// Unset the original DSL, since this will use a `bool` query instead.
 				unset( $formatted_args['query']['match_all'] );
+				// Add bool query with filters.
 				$formatted_args['query']['bool']['filter'] = $formatted_args['post_filter']['bool']['must'];
 			}
 

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -173,7 +173,6 @@ class VIP_Enterprise_Search extends Adapter {
 				// Add bool query with filters.
 				$formatted_args['query']['bool']['filter'] = $formatted_args['post_filter']['bool']['must'];
 			}
-
 		}
 
 		// Add requested aggregations.

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -164,7 +164,13 @@ class VIP_Enterprise_Search extends Adapter {
 					$formatted_args['query']['function_score']['query']['bool']['filter'] ?? [],
 					$formatted_args['post_filter']['bool']['must']
 				);
+			} elseif ( ! empty( $formatted_args['query']['match_all'] ) ) {
+				// Add filters to a match_all queries. This happens on secondary queries that use ep_integrate.
+				$formatted_args['query']['bool']['must']['match_all'] = $formatted_args['query']['match_all'];
+				unset( $formatted_args['query']['match_all'] );
+				$formatted_args['query']['bool']['filter'] = $formatted_args['post_filter']['bool']['must'];
 			}
+
 		}
 
 		// Add requested aggregations.

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -165,9 +165,10 @@ class VIP_Enterprise_Search extends Adapter {
 					$formatted_args['post_filter']['bool']['must']
 				);
 			} elseif ( ! empty( $formatted_args['query']['match_all'] ) ) {
-				// Add filters to a match_all queries. This happens on secondary queries that use ep_integrate.
+				// This condition triggers on secondary queries that use ep_integrate.
+				// Adding filters to match_all queries requires converting it to a bool query with the match_all clause nested within.
 				$formatted_args['query']['bool']['must']['match_all'] = $formatted_args['query']['match_all'];
-				// Unset the original DSL, since this will use a `bool` query instead.
+				// Unset the original DSL, since this will use a bool query instead.
 				unset( $formatted_args['query']['match_all'] );
 				// Add bool query with filters.
 				$formatted_args['query']['bool']['filter'] = $formatted_args['post_filter']['bool']['must'];


### PR DESCRIPTION
For secondary queries that utilize WP_Query and ep_integrate, the DSL uses a `match_all` query. This PR adds aggregate filtering support for such queries.