### PR TITLE
Fix: Update hook used to parse aggregations

### DIFF
--- a/lib/adapters/class-searchpress.php
+++ b/lib/adapters/class-searchpress.php
@@ -8,6 +8,7 @@
 namespace Elasticsearch_Extensions\Adapters;
 
 use Elasticsearch_Extensions\REST_API\Post_Suggestion_Search_Handler;
+use SP_WP_Search;
 use WP_Query;
 
 use function SP_Integration;
@@ -61,11 +62,19 @@ class SearchPress extends Adapter {
 	 * @return string The modified SQL for the posts_request operation.
 	 */
 	public function extract_aggs_from_results( $sql, $query ) {
+		// Only attempt to get aggs from results for the main search query.
 		if ( ! $query->is_main_query() || ! $query->is_search() ) {
 			return $sql;
 		}
 
-		$aggs = SP_Integration()->search_obj->get_results( 'facets' );
+		// Attempt to get the SP_WP_Search object. Bail if it isn't set.
+		$sp_wp_search = SP_Integration()->search_obj;
+		if ( ! $sp_wp_search instanceof SP_WP_Search ) {
+			return $sql;
+		}
+
+		// If we have facets, parse them.
+		$aggs = $sp_wp_search->get_results( 'facets' );
 		if ( ! empty( $aggs ) ) {
 			$this->parse_aggregations( $aggs );
 		}


### PR DESCRIPTION
The `sp_pre_search_results` filter doesn't appear to exist, and isn't working for parsing aggregations. I've replaced this with a hook on `posts_request` that fires immediately after SearchPress does the same thing here:

https://github.com/alleyinteractive/searchpress/blob/5a23d028e9bf3aec8f80cee768d9e8c0db2db1c9/lib/class-sp-integration.php#L86

At this point, the search object is populated:

https://github.com/alleyinteractive/searchpress/blob/5a23d028e9bf3aec8f80cee768d9e8c0db2db1c9/lib/class-sp-integration.php#L200

Which means we can use the `SP_Integration` singleton helper to get the instance of the class, get the search object, and extract facets from it.