### PR TITLE
Add ability to configure/restrict indexing by post status

### DIFF
--- a/lib/adapters/class-adapter.php
+++ b/lib/adapters/class-adapter.php
@@ -78,6 +78,13 @@ abstract class Adapter implements Hookable {
 	private array $restricted_post_types = [];
 
 	/**
+	 * An optional array of indexable post statuses to restrict to.
+	 *
+	 * @var string[]
+	 */
+	private array $restricted_post_statuses = [];
+
+	/**
 	 * An optional array of taxonomies to restrict search to.
 	 *
 	 * @var string[]
@@ -387,6 +394,15 @@ abstract class Adapter implements Hookable {
 	}
 
 	/**
+	 * Gets the list of restricted post statuses.
+	 *
+	 * @return string[] The list of restricted post statuses.
+	 */
+	protected function get_restricted_post_statuses(): array {
+		return $this->restricted_post_statuses;
+	}
+
+	/**
 	 * Gets the list of restricted taxonomies.
 	 *
 	 * @return string[] The list of restricted taxonomy slugs.
@@ -486,6 +502,15 @@ abstract class Adapter implements Hookable {
 	 */
 	public function restrict_post_types( array $post_types ): void {
 		$this->restricted_post_types = $post_types;
+	}
+
+	/**
+	 * Restricts indexable post statuses to the provided list.
+	 *
+	 * @param string[] $post_statuses The array of indexabled post statuses to restrict to.
+	 */
+	public function restrict_post_statuses( array $post_statuses ): void {
+		$this->restricted_post_statuses = $post_statuses;
 	}
 
 	/**

--- a/lib/adapters/class-searchpress.php
+++ b/lib/adapters/class-searchpress.php
@@ -499,8 +499,8 @@ class SearchPress extends Adapter {
 	public function unhook(): void {
 		// Unregister filter hooks.
 		remove_filter( 'sp_pre_search_results', [ $this, 'extract_aggs_from_results' ] );
-		remove_filter( 'sp_config_sync_post_types', [ $this, 'apply_sync_post_statuses' ] );
-		remove_filter( 'sp_config_sync_statuses', [ $this, 'apply_sync_post_types' ] );
+		remove_filter( 'sp_config_sync_post_types', [ $this, 'apply_sync_post_types' ] );
+		remove_filter( 'sp_config_sync_statuses', [ $this, 'apply_sync_post_statuses' ] );
 		remove_filter( 'sp_config_mapping', [ $this, 'add_search_suggest_to_mapping' ] );
 		remove_filter( 'sp_post_pre_index', [ $this, 'add_search_suggest_to_indexed_post_data' ] );
 		remove_filter( 'sp_search_query_args', [ $this, 'add_aggs_to_es_query' ] );

--- a/lib/adapters/class-searchpress.php
+++ b/lib/adapters/class-searchpress.php
@@ -15,39 +15,6 @@ use Elasticsearch_Extensions\REST_API\Post_Suggestion_Search_Handler;
 class SearchPress extends Adapter {
 
 	/**
-	 * Registers action and/or filter hooks with WordPress.
-	 */
-	public function hook(): void {
-		// Register filter hooks.
-		add_filter( 'sp_pre_search_results', [ $this, 'extract_aggs_from_results' ], 10, 2 );
-		add_filter( 'sp_config_sync_post_types', [ $this, 'apply_sync_post_types' ] );
-		add_filter( 'sp_config_mapping', [ $this, 'add_search_suggest_to_mapping' ] );
-		add_filter( 'sp_post_pre_index', [ $this, 'add_search_suggest_to_indexed_post_data' ], 10, 2 );
-		add_filter( 'sp_search_query_args', [ $this, 'add_aggs_to_es_query' ] );
-		add_filter( 'sp_searchable_post_types', [ $this, 'apply_searchable_post_types' ] );
-		add_filter( 'sp_post_allowed_meta', [ $this, 'apply_allowed_meta' ] );
-		add_filter( 'sp_post_pre_index', [ $this, 'apply_allowed_taxonomies' ] );
-		add_filter( 'wp_rest_search_handlers', [ $this, 'filter__wp_rest_search_handlers' ] );
-	}
-
-	/**
-	 * Unregisters action and/or filter hooks that were registered in the hook
-	 * method.
-	 */
-	public function unhook(): void {
-		// Unregister filter hooks.
-		remove_filter( 'sp_pre_search_results', [ $this, 'extract_aggs_from_results' ] );
-		remove_filter( 'sp_config_sync_post_types', [ $this, 'apply_sync_post_types' ] );
-		remove_filter( 'sp_config_mapping', [ $this, 'add_search_suggest_to_mapping' ] );
-		remove_filter( 'sp_post_pre_index', [ $this, 'add_search_suggest_to_indexed_post_data' ] );
-		remove_filter( 'sp_search_query_args', [ $this, 'add_aggs_to_es_query' ] );
-		remove_filter( 'sp_searchable_post_types', [ $this, 'apply_searchable_post_types' ] );
-		remove_filter( 'sp_post_allowed_meta', [ $this, 'apply_allowed_meta' ] );
-		remove_filter( 'sp_post_pre_index', [ $this, 'apply_allowed_taxonomies' ] );
-		remove_filter( 'wp_rest_search_handlers', [ $this, 'filter__wp_rest_search_handlers' ] );
-	}
-
-	/**
 	 * A callback for the sp_pre_search_results action hook. Parses aggregations
 	 * from the raw Elasticsearch response and adds the buckets to the
 	 * configured aggregations.
@@ -80,6 +47,26 @@ class SearchPress extends Adapter {
 	public function apply_sync_post_types( $post_types ) {
 		$restricted_post_types = $this->get_restricted_post_types();
 		return empty( $restricted_post_types ) ? $post_types : $restricted_post_types;
+	}
+
+	/**
+	 * A callback for the sp_config_sync_statuses filter hook. Filters the list
+	 * of post statuses that should be indexed in SearchPress based on what was
+	 * configured. If no restrictions were specified, uses the default list.
+	 *
+	 * @param array $post_statuses Indexabled post statuses.
+	 * @return string[] The modified list of post status to index.
+	 */
+	public function apply_sync_post_statuses( $post_statuses ): array {
+
+		// Determine whether we should filter the list or not.
+		$restricted_post_statuses = $this->get_restricted_post_statuses();
+
+		if ( empty( $restricted_post_statuses ) ) {
+			return $post_statuses;
+		}
+
+		return array_unique( array_merge( $post_statuses, $restricted_post_statuses ) );
 	}
 
 	/**
@@ -486,5 +473,40 @@ class SearchPress extends Adapter {
 			// This isn't indexed in SearchPress by default.
 			'term_tt_id'                    => 'terms.%s.term_taxonomy_id',
 		];
+	}
+
+	/**
+	 * Registers action and/or filter hooks with WordPress.
+	 */
+	public function hook(): void {
+		// Register filter hooks.
+		add_filter( 'sp_pre_search_results', [ $this, 'extract_aggs_from_results' ], 10, 2 );
+		add_filter( 'sp_config_sync_post_types', [ $this, 'apply_sync_post_types' ] );
+		add_filter( 'sp_config_sync_statuses', [ $this, 'apply_sync_post_statuses' ] );
+		add_filter( 'sp_config_mapping', [ $this, 'add_search_suggest_to_mapping' ] );
+		add_filter( 'sp_post_pre_index', [ $this, 'add_search_suggest_to_indexed_post_data' ], 10, 2 );
+		add_filter( 'sp_search_query_args', [ $this, 'add_aggs_to_es_query' ] );
+		add_filter( 'sp_searchable_post_types', [ $this, 'apply_searchable_post_types' ] );
+		add_filter( 'sp_post_allowed_meta', [ $this, 'apply_allowed_meta' ] );
+		add_filter( 'sp_post_pre_index', [ $this, 'apply_allowed_taxonomies' ] );
+		add_filter( 'wp_rest_search_handlers', [ $this, 'filter__wp_rest_search_handlers' ] );
+	}
+
+	/**
+	 * Unregisters action and/or filter hooks that were registered in the hook
+	 * method.
+	 */
+	public function unhook(): void {
+		// Unregister filter hooks.
+		remove_filter( 'sp_pre_search_results', [ $this, 'extract_aggs_from_results' ] );
+		remove_filter( 'sp_config_sync_post_types', [ $this, 'apply_sync_post_statuses' ] );
+		remove_filter( 'sp_config_sync_statuses', [ $this, 'apply_sync_post_types' ] );
+		remove_filter( 'sp_config_mapping', [ $this, 'add_search_suggest_to_mapping' ] );
+		remove_filter( 'sp_post_pre_index', [ $this, 'add_search_suggest_to_indexed_post_data' ] );
+		remove_filter( 'sp_search_query_args', [ $this, 'add_aggs_to_es_query' ] );
+		remove_filter( 'sp_searchable_post_types', [ $this, 'apply_searchable_post_types' ] );
+		remove_filter( 'sp_post_allowed_meta', [ $this, 'apply_allowed_meta' ] );
+		remove_filter( 'sp_post_pre_index', [ $this, 'apply_allowed_taxonomies' ] );
+		remove_filter( 'wp_rest_search_handlers', [ $this, 'filter__wp_rest_search_handlers' ] );
 	}
 }

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -81,6 +81,26 @@ class VIP_Enterprise_Search extends Adapter {
 	}
 
 	/**
+	 * A callback for the ep_indexable_post_status filter hook. Filters the list
+	 * of post statuses that should be indexed in ElasticPress based on what was
+	 * configured. If no restrictions were specified, uses the default list.
+	 *
+	 * @param array $post_statuses Indexabled post statuses.
+	 * @return string[] The modified list of post statuses to index.
+	 */
+	public function filter__ep_indexable_post_statuses( $post_statuses ): array {
+
+		// Determine whether we should filter the list or not.
+		$restricted_post_statuses = $this->get_restricted_post_statuses();
+
+		if ( empty( $restricted_post_statuses ) ) {
+			return $post_statuses;
+		}
+
+		return array_unique( array_merge( $post_statuses, $restricted_post_statuses ) );
+	}
+
+	/**
 	 * A callback for the ep_post_mapping filter. Adds the 'search_suggest'
 	 * field to the mapping if search suggestions are enabled.
 	 *
@@ -251,7 +271,7 @@ class VIP_Enterprise_Search extends Adapter {
 
 	/**
 	 * A callback for the vip_search_post_meta_allow_list filter hook.
-	 * Filters the list of post meta fields that should be indexed in 
+	 * Filters the list of post meta fields that should be indexed in
 	 * ElasticPress based on what was configured.
 	 *
 	 * @param array $post_meta A list of meta keys.
@@ -547,6 +567,7 @@ class VIP_Enterprise_Search extends Adapter {
 
 		// Register filter hooks.
 		add_filter( 'ep_elasticpress_enabled', [ $this, 'filter__ep_elasticpress_enabled' ], 10, 2 );
+		add_filter( 'ep_indexable_post_status', [ $this, 'filter__ep_indexable_post_statuses' ] );
 		add_filter( 'ep_indexable_post_types', [ $this, 'filter__ep_indexable_post_types' ] );
 		add_filter( 'ep_post_mapping', [ $this, 'filter__ep_post_mapping' ] );
 		add_filter( 'ep_post_sync_args_post_prepare_meta', [ $this, 'filter__ep_post_sync_args_post_prepare_meta' ], 10, 2 );
@@ -568,6 +589,7 @@ class VIP_Enterprise_Search extends Adapter {
 
 		// Unregister filter hooks.
 		remove_filter( 'ep_elasticpress_enabled', [ $this, 'filter__ep_elasticpress_enabled' ] );
+		remove_filter( 'ep_indexable_post_status', [ $this, 'filter__ep_indexable_post_statuses' ] );
 		remove_filter( 'ep_indexable_post_types', [ $this, 'filter__ep_indexable_post_types' ] );
 		remove_filter( 'ep_post_mapping', [ $this, 'filter__ep_post_mapping' ] );
 		remove_filter( 'ep_post_sync_args_post_prepare_meta', [ $this, 'filter__ep_post_sync_args_post_prepare_meta' ] );


### PR DESCRIPTION
I opted to use the grammatically correct plural version: `statuses`. Even though ElasticPress uses the singular version.

The [Wiki](https://github.com/alleyinteractive/elasticsearch-extensions/wiki) must be updated after this is merged.

fixes #58 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the ability to restrict indexable post statuses for search operations.
	- Added a new filter hook for handling post statuses during indexing.
- **Refactor**
	- Updated methods to include and remove the new filter hook.
- **Documentation**
	- Minor updates to formatting and documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->