### PR TITLE
Add PHPCS checks for PHP 8.1 and 8.2

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,4 +12,4 @@ jobs:
   code-quality:
     uses: alleyinteractive/.github/.github/workflows/php-code-quality.yml@main
     with:
-      php: "8.1"
+      php: "8.2"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -11,3 +11,8 @@ on:
 jobs:
   code-quality:
     uses: alleyinteractive/.github/.github/workflows/php-code-quality.yml@main
+    with:
+      php:
+        default: "8.1"
+        required: false
+        type: string

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -12,7 +12,4 @@ jobs:
   code-quality:
     uses: alleyinteractive/.github/.github/workflows/php-code-quality.yml@main
     with:
-      php:
-        default: "8.1"
-        required: false
-        type: string
+      php: "8.1"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -12,4 +12,4 @@ jobs:
   coding-standards:
     uses: alleyinteractive/.github/.github/workflows/php-coding-standards.yml@main
     with:
-      php: "8.1"
+      php: "8.2"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -12,7 +12,4 @@ jobs:
   coding-standards:
     uses: alleyinteractive/.github/.github/workflows/php-coding-standards.yml@main
     with:
-      php:
-        default: "8.1"
-        required: false
-        type: string
+      php: "8.1"

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -11,3 +11,8 @@ on:
 jobs:
   coding-standards:
     uses: alleyinteractive/.github/.github/workflows/php-coding-standards.yml@main
+    with:
+      php:
+        default: "8.1"
+        required: false
+        type: string

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,11 +29,16 @@ jobs:
             multisite: 0
             wp_version: '6.4'
             es_adapter: 'vip-search'
-          - php: 8.0
+          - php: 8.1
             es_version: '6.8.23'
             multisite: 1
             wp_version: '6.1'
             es_adapter: 'searchpress'
+          - php: 8.1
+            es_version: '6.8.23'
+            multisite: 1
+            wp_version: '6.1'
+            es_adapter: 'vip-search'
     env:
       WP_CORE_DIR: /tmp/wordpress
       WP_VERSION: ${{ matrix.wp_version }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,41 +9,11 @@ jobs:
     strategy:
       fail-fast: false # do not fail fast, let all the failing tests fail.
       matrix:
-        php: [8.1]
-        es_version: [7.17.5]
-        multisite: [0]
+        php: [8.1, 8.2]
+        es_version: [7.17, 8.11]
+        multisite: [0, 1]
         wp_version: ["latest"]
-        include:
-          - php: 8.2
-            es_version: '7.17.5'
-            multisite: 0
-            wp_version: 'latest'
-            es_adapter: 'searchpress'
-          - php: 8.2
-            es_version: '7.17.5'
-            multisite: 0
-            wp_version: 'latest'
-            es_adapter: 'vip-search'
-          - php: 8.1
-            es_version: '7.17.5'
-            multisite: 0
-            wp_version: 'latest'
-            es_adapter: 'searchpress'
-          - php: 8.1
-            es_version: '7.17.5'
-            multisite: 0
-            wp_version: 'latest'
-            es_adapter: 'vip-search'
-          - php: 8.1
-            es_version: '6.8.23'
-            multisite: 1
-            wp_version: '6.2.3'
-            es_adapter: 'searchpress'
-          - php: 8.1
-            es_version: '6.8.23'
-            multisite: 1
-            wp_version: '6.2.3'
-            es_adapter: 'vip-search'
+        es_adapter: ["searchpress", "vip-search"]
     env:
       WP_CORE_DIR: /tmp/wordpress
       WP_VERSION: ${{ matrix.wp_version }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,6 +29,11 @@ jobs:
             multisite: 0
             wp_version: '6.4'
             es_adapter: 'vip-search'
+          - php: 7.4
+            es_version: '6.8.23'
+            multisite: 1
+            wp_version: '6.1'
+            es_adapter: 'searchpress'
     env:
       WP_CORE_DIR: /tmp/wordpress
       WP_VERSION: ${{ matrix.wp_version }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,7 +29,7 @@ jobs:
             multisite: 0
             wp_version: '6.4'
             es_adapter: 'vip-search'
-          - php: 7.4
+          - php: 8.0
             es_version: '6.8.23'
             multisite: 1
             wp_version: '6.1'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,11 +29,6 @@ jobs:
             multisite: 0
             wp_version: '6.4'
             es_adapter: 'vip-search'
-          - php: 7.4
-            es_version: '6.8.23'
-            multisite: 0
-            wp_version: '6.4'
-            es_adapter: 'searchpress'
     env:
       WP_CORE_DIR: /tmp/wordpress
       WP_VERSION: ${{ matrix.wp_version }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,10 +10,26 @@ jobs:
       fail-fast: false # do not fail fast, let all the failing tests fail.
       matrix:
         php: [8.1, 8.2]
-        es_version: [7.17, 8.11]
-        multisite: [0, 1]
+        es_version: [8.11]
+        multisite: [0]
         wp_version: ["latest"]
         es_adapter: ["searchpress", "vip-search"]
+        include:
+          - php: 8.2
+            es_version: '8.11'
+            multisite: 1
+            wp_version: 'latest'
+            es_adapter: 'searchpress'
+          - php: 8.2
+            es_version: '7.17'
+            multisite: 1
+            wp_version: 'latest'
+            es_adapter: 'vip-search'
+          - php: 8.1
+            es_version: '7.17'
+            multisite: 1
+            wp_version: 'latest'
+            es_adapter: 'searchpress'
     env:
       WP_CORE_DIR: /tmp/wordpress
       WP_VERSION: ${{ matrix.wp_version }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,23 +10,23 @@ jobs:
       fail-fast: false # do not fail fast, let all the failing tests fail.
       matrix:
         php: [8.1, 8.2]
-        es_version: [8.11]
+        es_version: [8.11.1]
         multisite: [0]
         wp_version: ["latest"]
         es_adapter: ["searchpress", "vip-search"]
         include:
           - php: 8.2
-            es_version: '8.11'
+            es_version: '8.11.1'
             multisite: 1
             wp_version: 'latest'
             es_adapter: 'searchpress'
           - php: 8.2
-            es_version: '7.17'
+            es_version: '7.17.15'
             multisite: 1
             wp_version: 'latest'
             es_adapter: 'vip-search'
           - php: 8.1
-            es_version: '7.17'
+            es_version: '7.17.15'
             multisite: 1
             wp_version: 'latest'
             es_adapter: 'searchpress'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,27 +17,32 @@ jobs:
           - php: 8.2
             es_version: '7.17.5'
             multisite: 0
-            wp_version: '6.4'
+            wp_version: 'latest'
+            es_adapter: 'searchpress'
+          - php: 8.2
+            es_version: '7.17.5'
+            multisite: 0
+            wp_version: 'latest'
+            es_adapter: 'vip-search'
+          - php: 8.1
+            es_version: '7.17.5'
+            multisite: 0
+            wp_version: 'latest'
             es_adapter: 'searchpress'
           - php: 8.1
             es_version: '7.17.5'
             multisite: 0
-            wp_version: '6.4'
-            es_adapter: 'searchpress'
-          - php: 8.1
-            es_version: '7.17.5'
-            multisite: 0
-            wp_version: '6.4'
+            wp_version: 'latest'
             es_adapter: 'vip-search'
           - php: 8.1
             es_version: '6.8.23'
             multisite: 1
-            wp_version: '6.1'
+            wp_version: '6.2.3'
             es_adapter: 'searchpress'
           - php: 8.1
             es_version: '6.8.23'
             multisite: 1
-            wp_version: '6.1'
+            wp_version: '6.2.3'
             es_adapter: 'vip-search'
     env:
       WP_CORE_DIR: /tmp/wordpress

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,25 +9,31 @@ jobs:
     strategy:
       fail-fast: false # do not fail fast, let all the failing tests fail.
       matrix:
-        php: [8.0]
+        php: [8.1]
         es_version: [7.17.5]
         multisite: [0]
         wp_version: ["latest"]
         include:
-          - php: 8.0
+          - php: 8.2
             es_version: '7.17.5'
             multisite: 0
-            wp_version: '6.1'
+            wp_version: '6.4'
             es_adapter: 'searchpress'
-          - php: 7.4
+          - php: 8.1
             es_version: '7.17.5'
             multisite: 0
-            wp_version: '6.1'
+            wp_version: '6.4'
+            es_adapter: 'searchpress'
+          - php: 8.1
+            es_version: '7.17.5'
+            multisite: 0
+            wp_version: '6.4'
             es_adapter: 'vip-search'
           - php: 7.4
             es_version: '6.8.23'
-            multisite: 1
-            wp_version: '6.1'
+            multisite: 0
+            wp_version: '6.4'
+            es_adapter: 'searchpress'
     env:
       WP_CORE_DIR: /tmp/wordpress
       WP_VERSION: ${{ matrix.wp_version }}

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -52,8 +52,6 @@
   </rule>
 
   <!-- Disallow functions deprecated and/or aliased for backwards compatibility -->
-  <rule ref="Generic.PHP.DeprecatedFunctions">
-    <type>warning</type>
-  </rule>
+  <rule ref="Generic.PHP.DeprecatedFunctions"/>
   <rule ref="Generic.PHP.ForbiddenFunctions"/>
 </ruleset>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -50,4 +50,8 @@
       <property name="prefixes" type="array" value="elasticsearch_extensions"/>
     </properties>
   </rule>
+
+  <!-- Disallow functions deprecated and/or aliased for backwards compatibility -->
+  <rule ref="Generic.PHP.DeprecatedFunctions"/>
+  <rule ref="Generic.PHP.ForbiddenFunctions"/>
 </ruleset>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -52,6 +52,8 @@
   </rule>
 
   <!-- Disallow functions deprecated and/or aliased for backwards compatibility -->
-  <rule ref="Generic.PHP.DeprecatedFunctions"/>
+  <rule ref="Generic.PHP.DeprecatedFunctions">
+    <type>warning</type>
+  </rule>
   <rule ref="Generic.PHP.ForbiddenFunctions"/>
 </ruleset>

--- a/composer.json
+++ b/composer.json
@@ -71,12 +71,12 @@
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^0.3.0",
-    "alleyinteractive/pest-plugin-wordpress": "dev-feature/php-8-1-upgrade",
+    "alleyinteractive/pest-plugin-wordpress": "^0.5.0",
     "alleyinteractive/searchpress": "dev-main",
     "automattic/vip-go-mu-plugins-built": "dev-master",
     "composer/installers": "^1.0",
     "wpackagist-plugin/elasticpress": "^4.2",
-    "yoast/phpunit-polyfills": "^1.0",
+    "yoast/phpunit-polyfills": "^2.0",
     "phpstan/extension-installer": "^1.1",
     "phpstan/phpstan": "^1.8",
     "szepeviktor/phpstan-wordpress": "^1.1.6"
@@ -91,5 +91,7 @@
       "composer install"
     ]
   },
-  "type": "wordpress-plugin"
+  "type": "wordpress-plugin",
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     }
   ],
   "require": {
-    "php": "^7.4 || ^8.0 || ^8.1 || ^8.2"
+    "php": "^8.0 || ^8.1 || ^8.2"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^0.3.0",

--- a/composer.json
+++ b/composer.json
@@ -79,8 +79,7 @@
     "yoast/phpunit-polyfills": "^1.0",
     "phpstan/extension-installer": "^1.1",
     "phpstan/phpstan": "^1.8",
-    "szepeviktor/phpstan-wordpress": "^1.1.6",
-    "mantle-framework/support": "^0.12.9"
+    "szepeviktor/phpstan-wordpress": "^1.1.6"
   },
   "scripts": {
     "phpcbf": "phpcbf .",

--- a/composer.json
+++ b/composer.json
@@ -66,8 +66,10 @@
       }
     }
   ],
+  "require": {
+    "php": "^8.1 || ^8.2"
+  },
   "require-dev": {
-    "php": "^7.4 || ^8.0",
     "alleyinteractive/alley-coding-standards": "^0.3.0",
     "alleyinteractive/pest-plugin-wordpress": "^0.4.0",
     "alleyinteractive/searchpress": "^0.4.1",

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^0.3.0",
-    "alleyinteractive/pest-plugin-wordpress": "^0.4.0",
+    "alleyinteractive/pest-plugin-wordpress": "^0.4.1",
     "alleyinteractive/searchpress": "^0.4.1",
     "automattic/vip-go-mu-plugins-built": "dev-master",
     "composer/installers": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -56,12 +56,12 @@
       "type": "package",
       "package": {
         "name": "alleyinteractive/searchpress",
-        "version": "0.4.1",
+        "version": "dev-main",
         "type": "wordpress-plugin",
         "source": {
           "url": "https://github.com/alleyinteractive/searchpress.git",
           "type": "git",
-          "reference": "v0.4.1"
+          "reference": "main"
         }
       }
     }

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     }
   ],
   "require": {
-    "php": "^8.1 || ^8.2"
+    "php": "^8.0 || ^8.1 || ^8.2"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^0.3.0",

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^0.3.0",
     "alleyinteractive/pest-plugin-wordpress": "dev-feature/php-8-1-upgrade",
-    "alleyinteractive/searchpress": "^0.4.1",
+    "alleyinteractive/searchpress": "dev-main",
     "automattic/vip-go-mu-plugins-built": "dev-master",
     "composer/installers": "^1.0",
     "wpackagist-plugin/elasticpress": "^4.2",

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     }
   ],
   "require": {
-    "php": "^8.0 || ^8.1 || ^8.2"
+    "php": "^8.1 || ^8.2"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^0.3.0",

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
     }
   ],
   "require": {
-    "php": "^8.0 || ^8.1 || ^8.2"
+    "php": "^7.4 || ^8.0 || ^8.1 || ^8.2"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^0.3.0",

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^0.3.0",
-    "alleyinteractive/pest-plugin-wordpress": "^0.4.1",
+    "alleyinteractive/pest-plugin-wordpress": "dev-feature/php-8-1-upgrade",
     "alleyinteractive/searchpress": "^0.4.1",
     "automattic/vip-go-mu-plugins-built": "dev-master",
     "composer/installers": "^1.0",
@@ -79,7 +79,8 @@
     "yoast/phpunit-polyfills": "^1.0",
     "phpstan/extension-installer": "^1.1",
     "phpstan/phpstan": "^1.8",
-    "szepeviktor/phpstan-wordpress": "^1.1.6"
+    "szepeviktor/phpstan-wordpress": "^1.1.6",
+    "mantle-framework/support": "^0.12.9"
   },
   "scripts": {
     "phpcbf": "phpcbf .",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,8 @@
 	colors="true"
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="false"
+	convertWarningsToExceptions="true"
+	convertDeprecationsToExceptions="false"
 >
 	<testsuites>
 		<testsuite name="searchpress">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -5,7 +5,6 @@
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
 	convertWarningsToExceptions="true"
-	convertDeprecationsToExceptions="false"
 >
 	<testsuites>
 		<testsuite name="searchpress">

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,7 @@
 	colors="true"
 	convertErrorsToExceptions="true"
 	convertNoticesToExceptions="true"
-	convertWarningsToExceptions="true"
+	convertWarningsToExceptions="false"
 >
 	<testsuites>
 		<testsuite name="searchpress">

--- a/tests/includes/class-adapter-unit-test-case.php
+++ b/tests/includes/class-adapter-unit-test-case.php
@@ -9,7 +9,7 @@
 /**
  * Adapter_UnitTestCase class.
  */
-abstract class Adapter_UnitTestCase extends \Pest\PestPluginWordPress\FrameworkTestCase {
+abstract class Adapter_UnitTestCase extends Mantle\Testkit\Test_Case {
 
 	/**
 	 * Flush the index.

--- a/tests/test-sample.php
+++ b/tests/test-sample.php
@@ -9,7 +9,7 @@
 /**
  * A sample test so we can run phpunit. Needs to be replaced by actual tests.
  */
-class Test_Sample extends \Pest\PestPluginWordPress\FrameworkTestCase {
+class Test_Sample extends \Mantle\Testkit\Test_Case {
 
 	/**
 	 * A sample test.


### PR DESCRIPTION
Resolves #5 

This updates the plugin configs to enable support for PHP 8.1 and 8.2.
- Supported versions of PHP 8.1 and later
- Supported versions of WordPress 6.2 and later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the Continuous Integration (CI) testing documentation to reflect support for PHP versions 8.1 and 8.2, and WordPress version 6.4.

- **Refactor**
  - Enhanced the CI/CD workflows to test against the latest supported PHP and WordPress versions, ensuring compatibility and performance.

- **Chores**
  - Adjusted CI/CD configurations to align with updated coding standards and quality checks for PHP 8.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->