### PR TITLE
TECH-25: [elasticsearch-extensions] Issue 42 - Custom Queries

### DIFF
--- a/lib/adapters/class-adapter.php
+++ b/lib/adapters/class-adapter.php
@@ -601,7 +601,7 @@ abstract class Adapter implements Hookable {
 	 *
 	 * @return array The response from the Elasticsearch server.
 	 */
-	abstract public function search( array $es_args );
+	abstract public function search( array $es_args ): array;
 
 	/**
 	 * Suggest posts that match the given search term.

--- a/lib/adapters/class-adapter.php
+++ b/lib/adapters/class-adapter.php
@@ -597,13 +597,11 @@ abstract class Adapter implements Hookable {
 	/**
 	 * Query Elasticsearch directly. Must be implemented in child classes for specific adapters.
 	 *
-	 * @param array $es_args       Arguments to pass to the Elasticsearch server.
+	 * @param array $es_args Arguments to pass to the Elasticsearch server.
 	 *
-	 * @return array|\WP_Error The response from the Elasticsearch server.
+	 * @return array The response from the Elasticsearch server.
 	 */
-	public function search( array $es_args ) {
-		return new \WP_Error( 'not_implemented', 'Method `search()` must be implemented by the child class' );
-	}
+	abstract public function search( array $es_args );
 
 	/**
 	 * Suggest posts that match the given search term.

--- a/lib/adapters/class-adapter.php
+++ b/lib/adapters/class-adapter.php
@@ -601,7 +601,9 @@ abstract class Adapter implements Hookable {
 	 *
 	 * @return array The response from the Elasticsearch server.
 	 */
-	abstract protected function search( array $es_args ): array;
+	public function search( array $es_args ): array {
+		throw new \Exception( 'Method `search()` must be implemented by the child class' );
+	}
 
 	/**
 	 * Suggest posts that match the given search term.

--- a/lib/adapters/class-adapter.php
+++ b/lib/adapters/class-adapter.php
@@ -598,10 +598,10 @@ abstract class Adapter implements Hookable {
 	 * Query Elasticsearch directly. Must be implemented in child classes for specific adapters.
 	 *
 	 * @param array $es_args       Arguments to pass to the Elasticsearch server.
-	 * @param array $wp_query_args Arguments to pass to the WordPress query.
-	 * @return array|object The response from the Elasticsearch server.
+	 *
+	 * @return array The response from the Elasticsearch server.
 	 */
-	abstract protected function search( array $es_args, array $wp_query_args = [] ): array|object;
+	abstract protected function search( array $es_args ): array;
 
 	/**
 	 * Suggest posts that match the given search term.

--- a/lib/adapters/class-adapter.php
+++ b/lib/adapters/class-adapter.php
@@ -601,7 +601,7 @@ abstract class Adapter implements Hookable {
 	 * @param array $wp_query_args Arguments to pass to the WordPress query.
 	 * @return array|object The response from the Elasticsearch server.
 	 */
-	abstract protected function query_es( array $es_args, array $wp_query_args = [] ): array|object;
+	abstract protected function search( array $es_args, array $wp_query_args = [] ): array|object;
 
 	/**
 	 * Suggest posts that match the given search term.

--- a/lib/adapters/class-adapter.php
+++ b/lib/adapters/class-adapter.php
@@ -599,9 +599,10 @@ abstract class Adapter implements Hookable {
 	 *
 	 * @param array $es_args       Arguments to pass to the Elasticsearch server.
 	 *
-	 * @return array The response from the Elasticsearch server.
+	 * @return ?array The response from the Elasticsearch server.
+	 * @throws \Exception
 	 */
-	public function search( array $es_args ): array {
+	public function search( array $es_args ): ?array {
 		throw new \Exception( 'Method `search()` must be implemented by the child class' );
 	}
 

--- a/lib/adapters/class-adapter.php
+++ b/lib/adapters/class-adapter.php
@@ -595,6 +595,14 @@ abstract class Adapter implements Hookable {
 	}
 
 	/**
+	 * Query Elasticsearch directly. Must be implemented in child classes for specific adapters.
+	 *
+	 * @param array $es_args Arguments to pass to the Elasticsearch server.
+	 * @return array|object The response from the Elasticsearch server.
+	 */
+	abstract protected function query_es( array $es_args ): array|object;
+
+	/**
 	 * Suggest posts that match the given search term.
 	 *
 	 * @param string $search Search string.

--- a/lib/adapters/class-adapter.php
+++ b/lib/adapters/class-adapter.php
@@ -597,10 +597,11 @@ abstract class Adapter implements Hookable {
 	/**
 	 * Query Elasticsearch directly. Must be implemented in child classes for specific adapters.
 	 *
-	 * @param array $es_args Arguments to pass to the Elasticsearch server.
+	 * @param array $es_args       Arguments to pass to the Elasticsearch server.
+	 * @param array $wp_query_args Arguments to pass to the WordPress query.
 	 * @return array|object The response from the Elasticsearch server.
 	 */
-	abstract protected function query_es( array $es_args ): array|object;
+	abstract protected function query_es( array $es_args, array $wp_query_args = [] ): array|object;
 
 	/**
 	 * Suggest posts that match the given search term.

--- a/lib/adapters/class-adapter.php
+++ b/lib/adapters/class-adapter.php
@@ -599,11 +599,10 @@ abstract class Adapter implements Hookable {
 	 *
 	 * @param array $es_args       Arguments to pass to the Elasticsearch server.
 	 *
-	 * @return ?array The response from the Elasticsearch server.
-	 * @throws \Exception
+	 * @return array|\WP_Error The response from the Elasticsearch server.
 	 */
-	public function search( array $es_args ): ?array {
-		throw new \Exception( 'Method `search()` must be implemented by the child class' );
+	public function search( array $es_args ) {
+		return new \WP_Error( 'not_implemented', 'Method `search()` must be implemented by the child class' );
 	}
 
 	/**

--- a/lib/adapters/class-generic.php
+++ b/lib/adapters/class-generic.php
@@ -34,7 +34,7 @@ class Generic extends Adapter {
 	 *
 	 * @return array The response from the Elasticsearch server.
 	 */
-	public function search( array $es_args ) {
+	public function search( array $es_args ): array {
 		return [];
 	}
 

--- a/lib/adapters/class-generic.php
+++ b/lib/adapters/class-generic.php
@@ -28,6 +28,17 @@ class Generic extends Adapter {
 	public function hook(): void {}
 
 	/**
+	 * Query Elasticsearch directly. Must be implemented in child classes for specific adapters.
+	 *
+	 * @param array $es_args Arguments to pass to the Elasticsearch server.
+	 *
+	 * @return array The response from the Elasticsearch server.
+	 */
+	public function search( array $es_args ) {
+		return [];
+	}
+
+	/**
 	 * Unregisters action and/or filter hooks that were registered in the hook
 	 * method.
 	 */

--- a/lib/adapters/class-searchpress.php
+++ b/lib/adapters/class-searchpress.php
@@ -235,11 +235,11 @@ class SearchPress extends Adapter {
 	/**
 	 * Query Elasticsearch directly.
 	 *
-	 * @see \Elasticsearch_Extensions\Adapters\Adapter::query_es()
-	 * @param array $es_args Elasticsearch query arguments.
+	 * @param array $es_args       Elasticsearch query arguments.
+	 * @param array $wp_query_args Optional. An array of query arguments.
 	 * @return array|object Elasticsearch response. Defaults to array.
 	 */
-	protected function query_es( array $es_args ): array|object {
+	public function query_es( array $es_args, array $wp_query_args = [] ): array|object {
 		return SP_API()->search( wp_json_encode( $es_args ), [ 'output' => ARRAY_A ] );
 	}
 

--- a/lib/adapters/class-searchpress.php
+++ b/lib/adapters/class-searchpress.php
@@ -233,6 +233,17 @@ class SearchPress extends Adapter {
 	}
 
 	/**
+	 * Query Elasticsearch directly.
+	 *
+	 * @see \Elasticsearch_Extensions\Adapters\Adapter::query_es()
+	 * @param array $es_args Elasticsearch query arguments.
+	 * @return array|object Elasticsearch response.
+	 */
+	protected function query_es( array $es_args ): array|object {
+		return SP_API()->search( wp_json_encode( $es_args ), [ 'output' => ARRAY_A ] );
+	}
+
+	/**
 	 * Suggest posts that match the given search term.
 	 *
 	 * @param string $search Search string.

--- a/lib/adapters/class-searchpress.php
+++ b/lib/adapters/class-searchpress.php
@@ -237,7 +237,7 @@ class SearchPress extends Adapter {
 	 *
 	 * @see \Elasticsearch_Extensions\Adapters\Adapter::query_es()
 	 * @param array $es_args Elasticsearch query arguments.
-	 * @return array|object Elasticsearch response.
+	 * @return array|object Elasticsearch response. Defaults to array.
 	 */
 	protected function query_es( array $es_args ): array|object {
 		return SP_API()->search( wp_json_encode( $es_args ), [ 'output' => ARRAY_A ] );

--- a/lib/adapters/class-searchpress.php
+++ b/lib/adapters/class-searchpress.php
@@ -236,9 +236,10 @@ class SearchPress extends Adapter {
 	 * Query Elasticsearch directly.
 	 *
 	 * @param array $es_args       Elasticsearch query arguments.
-	 * @return array|object Elasticsearch response. Defaults to array.
+	 *
+	 * @return array Elasticsearch response.
 	 */
-	public function search( array $es_args ): array|object {
+	public function search( array $es_args ): array {
 		return SP_API()->search( wp_json_encode( $es_args ), [ 'output' => ARRAY_A ] );
 	}
 

--- a/lib/adapters/class-searchpress.php
+++ b/lib/adapters/class-searchpress.php
@@ -236,10 +236,9 @@ class SearchPress extends Adapter {
 	 * Query Elasticsearch directly.
 	 *
 	 * @param array $es_args       Elasticsearch query arguments.
-	 * @param array $wp_query_args Optional. An array of query arguments.
 	 * @return array|object Elasticsearch response. Defaults to array.
 	 */
-	public function search( array $es_args, array $wp_query_args = [] ): array|object {
+	public function search( array $es_args ): array|object {
 		return SP_API()->search( wp_json_encode( $es_args ), [ 'output' => ARRAY_A ] );
 	}
 

--- a/lib/adapters/class-searchpress.php
+++ b/lib/adapters/class-searchpress.php
@@ -239,7 +239,7 @@ class SearchPress extends Adapter {
 	 * @param array $wp_query_args Optional. An array of query arguments.
 	 * @return array|object Elasticsearch response. Defaults to array.
 	 */
-	public function query_es( array $es_args, array $wp_query_args = [] ): array|object {
+	public function search( array $es_args, array $wp_query_args = [] ): array|object {
 		return SP_API()->search( wp_json_encode( $es_args ), [ 'output' => ARRAY_A ] );
 	}
 

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -612,11 +612,11 @@ class VIP_Enterprise_Search extends Adapter {
 	 * Query Elasticsearch directly.
 	 *
 	 * @param array $es_args       Formatted es query arguments.
-	 * @return array|object The raw Elasticsearch response.
+	 * @return array The raw Elasticsearch response.
 	 *
 	 * @see \Elasticsearch_Extensions\Adapters\Adapter::query_es()
 	 */
-	public function search( array $es_args ): array|object {
+	public function search( array $es_args ): array {
 		// Get Elasticsearch instance from EP.
 		$elasticsearch = \ElasticPress\Elasticsearch::factory();
 		$type          = 'post';

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -617,7 +617,7 @@ class VIP_Enterprise_Search extends Adapter {
 	 *
 	 * @see \Elasticsearch_Extensions\Adapters\Adapter::query_es()
 	 */
-	public function query_es( array $es_args, array $wp_query_args = [] ): array|object {
+	public function search( array $es_args, array $wp_query_args = [] ): array|object {
 		// Get Elasticsearch instance from EP.
 		$elasticsearch = \ElasticPress\Elasticsearch::factory();
 		$type          = 'post';

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -619,11 +619,12 @@ class VIP_Enterprise_Search extends Adapter {
 	 */
 	public function search( array $es_args ): array {
 		// Get Elasticsearch instance from EP.
-		$type          = 'post';
-		$index         = $this->get_site_index( $type );
+		$type  = 'post';
+		$index = $this->get_site_index( $type );
 
 		// Execute the query.
 		$response = \ElasticPress\Elasticsearch::factory()->query( $index, $type, $es_args, [] );
+
 		return ! empty( $response ) ? $response : [];
 	}
 

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -583,7 +583,8 @@ class VIP_Enterprise_Search extends Adapter {
 	 */
 	private function get_site_index( string $slug = 'post' ): string {
 		$post_indexable = \ElasticPress\Indexables::factory()->get( $slug );
-		$index_name = $post_indexable->get_index_name( get_current_blog_id() );
+		$index_name     = $post_indexable->get_index_name( get_current_blog_id() );
+
 		return ! empty( $index_name ) ? $index_name : '';
 	}
 
@@ -618,7 +619,6 @@ class VIP_Enterprise_Search extends Adapter {
 	 */
 	public function search( array $es_args ): array {
 		// Get Elasticsearch instance from EP.
-		$elasticsearch = \ElasticPress\Elasticsearch::factory();
 		$type          = 'post';
 		$index         = $this->get_site_index( $type );
 

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -583,8 +583,8 @@ class VIP_Enterprise_Search extends Adapter {
 	 */
 	private function get_site_index( string $slug = 'post' ): string {
 		$post_indexable = \ElasticPress\Indexables::factory()->get( $slug );
-
-		return $post_indexable->get_index_name( get_current_blog_id() ) ?? '';
+		$index_name = $post_indexable->get_index_name( get_current_blog_id() );
+		return ! empty( $index_name ) ? $index_name : '';
 	}
 
 	/**
@@ -625,9 +625,7 @@ class VIP_Enterprise_Search extends Adapter {
 
 		// Execute the query.
 		$response = \ElasticPress\Elasticsearch::factory()->query( $index, $type, $es_args, $wp_query_args );
-		var_dump($response);
-		return [];
-
+		return ! empty( $response ) ? $response : [];
 	}
 
 	/**

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -576,6 +576,18 @@ class VIP_Enterprise_Search extends Adapter {
 	}
 
 	/**
+	 * Gets the post index name for the current site.
+	 *
+	 * @param string $slug Indexable slug. Defaults to 'post'.
+	 * @return string The index name.
+	 */
+	private function get_site_index( string $slug = 'post' ): string {
+		$post_indexable = \ElasticPress\Indexables::factory()->get( $slug );
+
+		return $post_indexable->get_index_name( get_current_blog_id() ) ?? '';
+	}
+
+	/**
 	 * Registers action and/or filter hooks with WordPress.
 	 */
 	public function hook(): void {
@@ -594,6 +606,28 @@ class VIP_Enterprise_Search extends Adapter {
 		add_filter( 'vip_search_post_meta_allow_list', [ $this, 'filter__vip_search_post_meta_allow_list' ] );
 		add_filter( 'vip_search_post_taxonomies_allow_list', [ $this, 'filter__vip_search_post_taxonomies_allow_list' ] );
 		add_filter( 'wp_rest_search_handlers', [ $this, 'filter__wp_rest_search_handlers' ] );
+	}
+
+	/**
+	 * Query Elasticsearch directly.
+	 *
+	 * @param array $es_args       Formatted es query arguments.
+	 * @param array $wp_query_args WP_Query args.
+	 * @return array|object The raw Elasticsearch response.
+	 *
+	 * @see \Elasticsearch_Extensions\Adapters\Adapter::query_es()
+	 */
+	public function query_es( array $es_args, array $wp_query_args = [] ): array|object {
+		// Get Elasticsearch instance from EP.
+		$elasticsearch = \ElasticPress\Elasticsearch::factory();
+		$type          = 'post';
+		$index         = $this->get_site_index( $type );
+
+		// Execute the query.
+		$response = \ElasticPress\Elasticsearch::factory()->query( $index, $type, $es_args, $wp_query_args );
+		var_dump($response);
+		return [];
+
 	}
 
 	/**

--- a/lib/adapters/class-vip-enterprise-search.php
+++ b/lib/adapters/class-vip-enterprise-search.php
@@ -612,19 +612,18 @@ class VIP_Enterprise_Search extends Adapter {
 	 * Query Elasticsearch directly.
 	 *
 	 * @param array $es_args       Formatted es query arguments.
-	 * @param array $wp_query_args WP_Query args.
 	 * @return array|object The raw Elasticsearch response.
 	 *
 	 * @see \Elasticsearch_Extensions\Adapters\Adapter::query_es()
 	 */
-	public function search( array $es_args, array $wp_query_args = [] ): array|object {
+	public function search( array $es_args ): array|object {
 		// Get Elasticsearch instance from EP.
 		$elasticsearch = \ElasticPress\Elasticsearch::factory();
 		$type          = 'post';
 		$index         = $this->get_site_index( $type );
 
 		// Execute the query.
-		$response = \ElasticPress\Elasticsearch::factory()->query( $index, $type, $es_args, $wp_query_args );
+		$response = \ElasticPress\Elasticsearch::factory()->query( $index, $type, $es_args, [] );
 		return ! empty( $response ) ? $response : [];
 	}
 

--- a/lib/class-controller.php
+++ b/lib/class-controller.php
@@ -387,6 +387,18 @@ class Controller implements Hookable {
 	}
 
 	/**
+	 * Directly query Elasticsearch.
+	 *
+	 * @param array $es_args The query to send to Elasticsearch.
+	 * @param array $wp_query_args The WP query args to send to Elasticsearch. Only used for VIP Search.
+	 *
+	 * @return array The response from Elasticsearch.
+	 */
+	public function query_es( array $es_args, array $wp_query_args = [] ) {
+		return $this->adapter->query_es( $es_args, $wp_query_args );
+	}
+
+	/**
 	 * Restricts indexable meta to the provided list.
 	 *
 	 * @param string[] $post_meta The array of meta fields to restrict to.

--- a/lib/class-controller.php
+++ b/lib/class-controller.php
@@ -393,7 +393,7 @@ class Controller implements Hookable {
 	 *
 	 * @return array The response from Elasticsearch.
 	 */
-	public function search( array $es_args ) {
+	public function search( array $es_args ): array {
 		return $this->adapter->search( $es_args );
 	}
 

--- a/lib/class-controller.php
+++ b/lib/class-controller.php
@@ -390,12 +390,11 @@ class Controller implements Hookable {
 	 * Directly query Elasticsearch.
 	 *
 	 * @param array $es_args The query to send to Elasticsearch.
-	 * @param array $wp_query_args The WP query args to send to Elasticsearch. Only used for VIP Search.
 	 *
 	 * @return array The response from Elasticsearch.
 	 */
-	public function query_es( array $es_args, array $wp_query_args = [] ) {
-		return $this->adapter->query_es( $es_args, $wp_query_args );
+	public function search( array $es_args ) {
+		return $this->adapter->search( $es_args );
 	}
 
 	/**

--- a/tests/includes/class-searchpress-unit-test-case.php
+++ b/tests/includes/class-searchpress-unit-test-case.php
@@ -46,7 +46,7 @@ class SearchPress_Adapter_UnitTestCase extends Adapter_UnitTestCase {
 		self::$sp_settings = SP_Config()->get_settings();
 	}
 
-	public function tear_down() {
+	public function tear_down(): void {
 		$this->reset_post_types();
 		$this->reset_taxonomies();
 		$this->reset_post_statuses();


### PR DESCRIPTION
## Summary

Resolves #42 

Enable adapter agnostic direct custom es queries.

For example:
```php
add_action( 'init', function () {
	add_action( 'init', function () {
	$current_post_id = 163; // arbitrary post for testing.
	$es_args         = [
		'profile'     => false,
		'from'        => 0,
		'size'        => 5,
		'query'       => [
			'function_score' => [
				'query'      => [
					'more_like_this' => [
						'like'            => [
							'_id' => $current_post_id,
						],
						'fields'          => [
							'post_title',
						],
						'min_term_freq'   => 1,
						'max_query_terms' => 12,
						'min_doc_freq'    => 1,
					],
				],
				'functions'  => [
					[
						'gauss' => [
							'post_date_gmt.date' => [
								'decay'  => 0.9,
								'offset' => '0d',
								'scale'  => '360d',
							],
						],
					],
				],
				'score_mode' => 'multiply',
				'boost_mode' => 'multiply',
			],
		],
		'post_filter' => [
			'bool' => [
				'must' => [
					[
						'terms' => [
							'post_type.raw' => [
								'post',
							],
						],
					],
					[
						'terms' => [
							'post_status' => [
								'publish',
							],
						],
					],
				],
			],
		],
	];

	$es_extensions_controller = elasticsearch_extensions();
	$hits = $es_extensions_controller->search( $es_args );
	print_r( $hits );
} );
```

## Notes for reviewers

None.

## Changelog entries

### Added
- Create a new method on the controller called `search` that accepts an array of DSL.

### Changed

### Deprecated

### Removed

### Fixed

### Security

## Ticket(s)

- [TECH-25](https://alleyinteractive.atlassian.net/browse/TECH-25)


[TECH-25]: https://alleyinteractive.atlassian.net/browse/TECH-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ