### PR TITLE
Issue-84: The `custom_date_range` aggregation does not allow for removing the start date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.2.0 - 2025-05-20
+
+### Fixed
+
+- **Breaking change:** Change custom date range aggregation query variable from a single array `custom_date_range` to two separate variables `date_gte` and `date_lte`. This resolves an issue ([#84](https://github.com/alleyinteractive/elasticsearch-extensions/issues/84)) where if the start date was cleared, the end date would incorrectly replace the start date and the end date would be cleared. **Developers using the form provided in the custom date range class do not need to update their code, but those using custom processing with the `custom_date_range` parameter must update their code to use `date_gte` and `date_lte` instead.** 
+
+## 0.1.0 - 2025-05-13
+
+- Initial release of the plugin
+
+### Added
+
+- Add post meta and term aggregations
+- Add SearchPress adapter
+
+### Fixed
+
+- Fix fatal error when param is of type `WP_Term_Query`
+
 ## [Unreleased]
 
 - Initial creation of the plugin

--- a/lib/aggregations/class-custom-date-range.php
+++ b/lib/aggregations/class-custom-date-range.php
@@ -23,14 +23,14 @@ class Custom_Date_Range extends Aggregation {
 	 *
 	 * @var string
 	 */
-	protected string $query_var_start = 'custom_date_range_start';
+	protected string $query_var_start = 'date_gte';
 
 	/**
 	 * The query var for the end date.
 	 *
 	 * @var string
 	 */
-	protected string $query_var_end = 'custom_date_range_end';
+	protected string $query_var_end = 'date_lte';
 
 	/**
 	 * Configure the Custom Date Range aggregation.
@@ -51,7 +51,7 @@ class Custom_Date_Range extends Aggregation {
 	 * additional processing on date query values.
 	 *
 	 * @param string $key Optional. The key to look up. Defaults to the current query var.
-	 *
+	 * 
 	 * @return string[] The values for the given key.
 	 */
 	protected function extract_query_values( string $key = '' ): array {


### PR DESCRIPTION
### Summary

Fixes #84

This pull request addresses a bug in the `custom_date_range` aggregation where removing the start date causes the end date to replace the start date, and the end date becomes empty. The issue stems from the `array_filter()` in `Custom_Date_Range->extract_query_values()` filtering out empty array elements, making it unclear whether the start or end date was removed.

### Changes

- Updates the custom date range aggregation to use separate query variables for the date range (`custom_date_range_start` and `custom_date_range_end`), instead of an array of values (`custom_date_range`)

### Test Plan

1. Build a search query using `elasticsearch-extensions` with `custom_date_aggregation`.
2. Clear the start date and verify that the data structure reflects `[ '', '2025-01-01' ]` instead of `[ '2025-01-01' ]`.
3. Run the test suite to confirm no regressions and the new test cases pass as expected.

### Additional Notes

This fix ensures that the `custom_date_range` aggregation properly handles empty start or end dates, maintaining clarity in the data structure.
