### PR TITLE
Release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## 0.2.1 - 2026-01-15
 
 ### Changed
 

--- a/elasticsearch-extensions.php
+++ b/elasticsearch-extensions.php
@@ -7,7 +7,7 @@
  * Author URI:   https://alley.co/
  * Text Domain:  elasticsearch-extensions
  * Domain Path:  /languages
- * Version:      0.2.0
+ * Version:      0.2.1
  *
  * @package Elasticsearch_Extensions
  */


### PR DESCRIPTION
## Summary

Bumps the version number to prepare for a new release that includes changes from https://github.com/alleyinteractive/elasticsearch-extensions/pull/89 and sets the proper version number in the plugin header.